### PR TITLE
Grant a dedicated management role

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return [
     'label' => 'extension-tao-testqti-previewer',
     'description' => 'extension that provides QTI test previewer',
     'license'     => 'GPL-2.0',
-    'version' => '0.1.1',
+    'version' => '0.1.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=19.5.0',
@@ -34,9 +34,9 @@ return [
         'taoQtiTest' => '>=25.8.0',
         'taoOutcomeUi' => '>=5.10.0'
     ],
-    'managementRole' => 'http://www.tao.lu/Ontologies/TAOTest.rdf#TaoQtiManagerRole',
+    'managementRole' => 'http://www.tao.lu/Ontologies/TAOTestPreviewer.rdf#TaoQtiManagerRole',
     'acl' => [
-        ['grant', 'http://www.tao.lu/Ontologies/TAOTest.rdf#TaoQtiManagerRole', ['ext' => 'taoQtiTestPreviewer']],
+        ['grant', 'http://www.tao.lu/Ontologies/TAOTestPreviewer.rdf#TaoQtiManagerRole', ['ext' => 'taoQtiTestPreviewer']],
     ],
     'install' => [
         'php' => [

--- a/manifest.php
+++ b/manifest.php
@@ -37,6 +37,7 @@ return [
     'managementRole' => 'http://www.tao.lu/Ontologies/TAOTestPreviewer.rdf#TaoQtiManagerRole',
     'acl' => [
         ['grant', 'http://www.tao.lu/Ontologies/TAOTestPreviewer.rdf#TaoQtiManagerRole', ['ext' => 'taoQtiTestPreviewer']],
+        ['grant', 'http://www.tao.lu/Ontologies/TAOTest.rdf#TaoQtiManagerRole', ['ext' => 'taoQtiTestPreviewer']],
     ],
     'install' => [
         'php' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -67,5 +67,12 @@ class Updater extends \common_ext_ExtensionUpdater
         }
         
         $this->skip('0.1.0', '0.1.1');
+
+        if ($this->isVersion('0.1.1')) {
+            AclProxy::revokeRule(new AccessRule('grant', 'http://www.tao.lu/Ontologies/TAOTest.rdf#TestsManagerRole', array('ext'=>'taoQtiTestPreviewer', 'mod' => 'Previewer')));
+            AclProxy::applyRule(new AccessRule('grant', 'http://www.tao.lu/Ontologies/TAOTestPreviewer.rdf#TestsManagerRole', array('ext'=>'taoQtiTestPreviewer', 'mod' => 'Previewer')));
+
+            $this->setVersion('0.1.2');
+        }
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -71,6 +71,7 @@ class Updater extends \common_ext_ExtensionUpdater
         if ($this->isVersion('0.1.1')) {
             AclProxy::revokeRule(new AccessRule('grant', 'http://www.tao.lu/Ontologies/TAOTest.rdf#TestsManagerRole', array('ext'=>'taoQtiTestPreviewer', 'mod' => 'Previewer')));
             AclProxy::applyRule(new AccessRule('grant', 'http://www.tao.lu/Ontologies/TAOTestPreviewer.rdf#TestsManagerRole', array('ext'=>'taoQtiTestPreviewer', 'mod' => 'Previewer')));
+            AclProxy::applyRule(new AccessRule('grant', 'http://www.tao.lu/Ontologies/TAOTest.rdf#TaoQtiManagerRole', array('ext'=>'taoQtiTestPreviewer', 'mod' => 'Previewer')));
 
             $this->setVersion('0.1.2');
         }


### PR DESCRIPTION
This new extension was using the same management role of `taoQtiTest`, as it was built from an extracted part of it.

Simply redefine the management role to ensure it is unique and only related to this extension.