### PR TITLE
TAO-8138: [FE] Review of a specific result of test item fails

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return [
     'label' => 'extension-tao-testqti-previewer',
     'description' => 'extension that provides QTI test previewer',
     'license'     => 'GPL-2.0',
-    'version' => '2.1.0',
+    'version' => '2.1.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao'          => '>=30.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -87,6 +87,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.2.0');
         }
 
-        $this->skip('0.2.0', '2.1.0');
+        $this->skip('0.2.0', '2.1.1');
     }
 }

--- a/views/js/previewer/adapter/item/qtiItem.js
+++ b/views/js/previewer/adapter/item/qtiItem.js
@@ -22,8 +22,9 @@ define([
     'lodash',
     'core/logger',
     'taoQtiTestPreviewer/previewer/runner',
+    'ui/feedback',
     'css!taoQtiTestPreviewer/previewer/provider/item/css/item'
-], function (_, loggerFactory, previewerFactory) {
+], function (_, loggerFactory, previewerFactory, feedback) {
     'use strict';
 
     var logger = loggerFactory('taoQtiTest/previewer');
@@ -86,7 +87,11 @@ define([
 
             return previewerFactory(config)
                 .on('error', function (err) {
-                    logger.error(err);
+                    if (!_.isUndefined(err.message)) {
+                        feedback().error(err.message);
+                    } else {
+                        logger.error(err);
+                    }
                 })
                 .on('ready', function (runner) {
                     runner

--- a/views/js/previewer/adapter/item/qtiItem.js
+++ b/views/js/previewer/adapter/item/qtiItem.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
  */
 /**
  * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>


### PR DESCRIPTION
Relates to: https://oat-sa.atlassian.net/browse/TAO-8138

### Description
When the user tries to review a specific result of the delivery in Results tab the  Error occurs.
You should pass test using a user with the test-taker role (not guest user).
Found out that user's locale (language) impacts on the error. 
Exception triggers only for users with locale different from `English`.

### Solution
FE part:
Used `tao/ui/feedback` func. in order to display error in UI but not in the console.

![image](https://user-images.githubusercontent.com/5684414/57083936-00a9c900-6d02-11e9-8e32-6c8abc7a1afd.png)

