### PR TITLE
Feature/tao 8191/Add previewer component

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return [
     'version' => '2.4.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
-        'tao'          => '>=34.1.1',
+        'tao'          => '>=37.6.0',
         'taoTests'     => '>=12.0.0',
         'taoItems'     => '>=6.0.0',
         'taoQtiTest'   => '>=29.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return [
     'label' => 'extension-tao-testqti-previewer',
     'description' => 'extension that provides QTI test previewer',
     'license'     => 'GPL-2.0',
-    'version' => '2.3.0',
+    'version' => '2.4.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao'          => '>=34.1.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -87,6 +87,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.2.0');
         }
 
-        $this->skip('0.2.0', '2.3.0');
+        $this->skip('0.2.0', '2.4.0');
     }
 }

--- a/views/js/previewer/adapter/item/qtiItem.js
+++ b/views/js/previewer/adapter/item/qtiItem.js
@@ -68,7 +68,8 @@ define([
          * @returns {Object}
          */
         init(uri, state, config = {}) {
-
+            config.itemUri = uri;
+            config.itemState = state;
             config.plugins = Array.isArray(config.plugins) ? [...defaultPlugins, ...config.plugins] : defaultPlugins;
             return qtiItemPreviewerFactory(window.document.body, config)
                 .on('error', function (err) {
@@ -77,15 +78,6 @@ define([
                     } else {
                         logger.error(err);
                     }
-                })
-                .on('ready', function (runner) {
-                    runner
-                        .on('renderitem', function () {
-                            if (state) {
-                                runner.itemRunner.setState(state);
-                            }
-                        })
-                        .loadItem(uri);
                 });
         }
     };

--- a/views/js/previewer/adapter/item/qtiItem.js
+++ b/views/js/previewer/adapter/item/qtiItem.js
@@ -28,13 +28,13 @@ define([
 ], function (_, context, loggerFactory, previewerFactory, feedback) {
     'use strict';
 
-    var logger = loggerFactory('taoQtiTest/previewer');
+    const logger = loggerFactory('taoQtiTest/previewer');
 
     /**
      * List of required plugins that should be loaded in order to make the previewer work properly
      * @type {Object[]}
      */
-    var defaultPlugins = [{
+    const defaultPlugins = [{
         module: 'taoQtiTestPreviewer/previewer/plugins/controls/close',
         bundle: 'taoQtiTestPreviewer/loader/qtiPreviewer.min',
         category: 'controls'
@@ -105,7 +105,7 @@ define([
             //extra context config
             testRunnerConfig.loadFromBundle = !!context.bundle;
 
-            return previewerFactory(testRunnerConfig)
+            return previewerFactory(window.document.body, testRunnerConfig)
                 .on('error', function (err) {
                     if (!_.isUndefined(err.message)) {
                         feedback().error(err.message);

--- a/views/js/previewer/adapter/item/qtiItem.js
+++ b/views/js/previewer/adapter/item/qtiItem.js
@@ -20,12 +20,10 @@
  */
 define([
     'lodash',
-    'context',
     'core/logger',
-    'taoQtiTestPreviewer/previewer/runner',
-    'ui/feedback',
-    'css!taoQtiTestPreviewer/previewer/provider/item/css/item'
-], function (_, context, loggerFactory, previewerFactory, feedback) {
+    'taoQtiTestPreviewer/previewer/component/qtiItem',
+    'ui/feedback'
+], function (_, loggerFactory, qtiItemPreviewerFactory, feedback) {
     'use strict';
 
     const logger = loggerFactory('taoQtiTest/previewer');
@@ -71,41 +69,8 @@ define([
          */
         init(uri, state, config = {}) {
 
-            const plugins = Array.isArray(config.plugins) ? [...defaultPlugins, ...config.plugins] : defaultPlugins;
-            const testRunnerConfig = {
-                testDefinition: 'test-container',
-                serviceCallId: 'previewer',
-                providers: {
-                    runner: {
-                        id: 'qtiItemPreviewer',
-                        module: 'taoQtiTestPreviewer/previewer/provider/item/item',
-                        bundle: 'taoQtiTestPreviewer/loader/qtiPreviewer.min',
-                        category: 'runner'
-                    },
-                    proxy: {
-                        id: 'qtiItemPreviewerProxy',
-                        module: 'taoQtiTestPreviewer/previewer/proxy/item',
-                        bundle: 'taoQtiTestPreviewer/loader/qtiPreviewer.min',
-                        category: 'proxy'
-                    },
-                    communicator: {
-                        id: 'request',
-                        module: 'core/communicator/request',
-                        bundle: 'loader/vendor.min',
-                        category: 'communicator'
-                    },
-                    plugins,
-                },
-                options: {
-                    readOnly : config.readOnly,
-                    fullPage : config.fullPage
-                }
-            };
-
-            //extra context config
-            testRunnerConfig.loadFromBundle = !!context.bundle;
-
-            return previewerFactory(window.document.body, testRunnerConfig)
+            config.plugins = Array.isArray(config.plugins) ? [...defaultPlugins, ...config.plugins] : defaultPlugins;
+            return qtiItemPreviewerFactory(window.document.body, config)
                 .on('error', function (err) {
                     if (!_.isUndefined(err.message)) {
                         feedback().error(err.message);

--- a/views/js/previewer/component/qtiItem.js
+++ b/views/js/previewer/component/qtiItem.js
@@ -29,12 +29,11 @@ define([
      * Builds a test runner to preview test item
      * @param {jQuery|HTMLElement|String} container - The container in which renders the component
      * @param {Object} [config] - The testRunner options
+     * @param {String} [config.itemUri] - The URI of the item to load
+     * @param {Object} [config.itemState] - The state of the item when relevant
      * @param {Object[]} [config.plugins] - Additional plugins to load
      * @param {String} [config.fullPage] - Force the previewer to occupy the full window.
      * @param {String} [config.readOnly] - Do not allow to modify the previewed item.
-     * @param {Boolean} [config.replace] - When the component is appended to its container, clears the place before
-     * @param {Number|String} [config.width] - The width in pixels, or 'auto' to use the container's width
-     * @param {Number|String} [config.height] - The height in pixels, or 'auto' to use the container's height
      * @param {Function} [template] - An optional template for the component
      * @returns {previewer}
      */
@@ -65,14 +64,22 @@ define([
                 plugins: config.plugins || [],
             },
             options: {
-                readOnly : config.readOnly,
-                fullPage : config.fullPage
+                readOnly: config.readOnly,
+                fullPage: config.fullPage
             }
         };
 
         //extra context config
         testRunnerConfig.loadFromBundle = !!context.bundle;
 
-        return previewerFactory(container, testRunnerConfig, template);
+        return previewerFactory(container, testRunnerConfig, template)
+            .on('ready', runner => {
+                if (config.itemState) {
+                    runner.on('renderitem', () => runner.itemRunner.setState(config.itemState));
+                }
+                if (config.itemUri) {
+                    return runner.loadItem(config.itemUri);
+                }
+            });
     };
 });

--- a/views/js/previewer/component/qtiItem.js
+++ b/views/js/previewer/component/qtiItem.js
@@ -1,0 +1,78 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'context',
+    'taoQtiTestPreviewer/previewer/runner',
+    'css!taoQtiTestPreviewer/previewer/provider/item/css/item'
+], function (context, previewerFactory) {
+    'use strict';
+
+    /**
+     * Builds a test runner to preview test item
+     * @param {jQuery|HTMLElement|String} container - The container in which renders the component
+     * @param {Object} [config] - The testRunner options
+     * @param {Object[]} [config.plugins] - Additional plugins to load
+     * @param {String} [config.fullPage] - Force the previewer to occupy the full window.
+     * @param {String} [config.readOnly] - Do not allow to modify the previewed item.
+     * @param {Boolean} [config.replace] - When the component is appended to its container, clears the place before
+     * @param {Number|String} [config.width] - The width in pixels, or 'auto' to use the container's width
+     * @param {Number|String} [config.height] - The height in pixels, or 'auto' to use the container's height
+     * @param {Function} [template] - An optional template for the component
+     * @returns {previewer}
+     */
+    return function qtiItemPreviewerFactory(container, config = {}, template = null) {
+
+        const testRunnerConfig = {
+            testDefinition: 'test-container',
+            serviceCallId: 'previewer',
+            providers: {
+                runner: {
+                    id: 'qtiItemPreviewer',
+                    module: 'taoQtiTestPreviewer/previewer/provider/item/item',
+                    bundle: 'taoQtiTestPreviewer/loader/qtiPreviewer.min',
+                    category: 'runner'
+                },
+                proxy: {
+                    id: 'qtiItemPreviewerProxy',
+                    module: 'taoQtiTestPreviewer/previewer/proxy/item',
+                    bundle: 'taoQtiTestPreviewer/loader/qtiPreviewer.min',
+                    category: 'proxy'
+                },
+                communicator: {
+                    id: 'request',
+                    module: 'core/communicator/request',
+                    bundle: 'loader/vendor.min',
+                    category: 'communicator'
+                },
+                plugins: config.plugins || [],
+            },
+            options: {
+                readOnly : config.readOnly,
+                fullPage : config.fullPage
+            }
+        };
+
+        //extra context config
+        testRunnerConfig.loadFromBundle = !!context.bundle;
+
+        return previewerFactory(container, testRunnerConfig, template);
+    };
+});

--- a/views/js/previewer/component/qtiItem.js
+++ b/views/js/previewer/component/qtiItem.js
@@ -61,7 +61,7 @@ define([
                     bundle: 'loader/vendor.min',
                     category: 'communicator'
                 },
-                plugins: config.plugins || [],
+                plugins: config.plugins || []
             },
             options: {
                 readOnly: config.readOnly,

--- a/views/js/previewer/runner.js
+++ b/views/js/previewer/runner.js
@@ -45,9 +45,9 @@ define([
 
         return runnerComponentFactory(container, config, template || runnerTpl)
             .on('render', function() {
-                const options = this.getConfig().options;
-                this.setState('fullpage', options.fullPage);
-                this.setState('readonly', options.readOnly);
+                const {fullPage, readOnly} = this.getConfig().options;
+                this.setState('fullpage', fullPage);
+                this.setState('readonly', readOnly);
             })
             .on('ready', function(runner) {
                 runner.on('destroy', () => this.destroy() );

--- a/views/js/previewer/runner.js
+++ b/views/js/previewer/runner.js
@@ -22,15 +22,14 @@
  * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
  */
 define([
-    'jquery',
-    'lodash',
     'taoTests/runner/runnerComponent',
     'tpl!taoQtiTestPreviewer/previewer/runner'
-], function ($, _, runnerComponentFactory, runnerTpl) {
+], function (runnerComponentFactory, runnerTpl) {
     'use strict';
 
     /**
      * Builds a test runner to preview test item
+     * @param {jQuery|HTMLElement|String} container - The container in which renders the component
      * @param {Object}   config - The testRunner options
      * @param {String}  [config.provider] - The provider to use
      * @param {Object[]} [config.providers] - A collection of providers to load.
@@ -39,16 +38,16 @@ define([
      * @param {Number|String} [config.height] - The height in pixels, or 'auto' to use the container's height
      * @param {Boolean} [config.options.fullPage] - Force the previewer to occupy the full window.
      * @param {Booleanh} [config.options.readOnly] - Do not allow to modify the previewed item.
-     * @param {jQuery|HTMLElement|String} container - The container in which renders the component
      * @param {Function} [template] - An optional template for the component
      * @returns {previewer}
      */
-    return function previewerFactory(config = {}, container, template) {
+    return function previewerFactory(container, config = {}, template = null) {
 
-        return runnerComponentFactory(container || $(document.body), config, template || runnerTpl)
+        return runnerComponentFactory(container, config, template || runnerTpl)
             .on('render', function() {
-                this.setState('fullpage', config.options.fullPage);
-                this.setState('readonly', config.options.readOnly);
+                const options = this.getConfig().options;
+                this.setState('fullpage', options.fullPage);
+                this.setState('readonly', options.readOnly);
             })
             .on('ready', function(runner) {
                 runner.on('destroy', () => this.destroy() );

--- a/views/js/test/previewer/adapter/qtiItem/test.js
+++ b/views/js/test/previewer/adapter/qtiItem/test.js
@@ -64,7 +64,7 @@ define([
             readOnly: true
         };
 
-        function dislpayPreviewer(config) {
+        function displayPreviewer(config) {
             $.mockjax.clear();
 
             $.mockjax({
@@ -114,7 +114,7 @@ define([
 
         assert.expect(1);
 
-        dislpayPreviewer(configReadOnly)
+        displayPreviewer(configReadOnly)
             .before('ready', function(e, runner) {
                 runner.after('renderitem.runnerComponent', function() {
                     assert.ok(true, 'The previewer has been rendered');
@@ -124,12 +124,12 @@ define([
 
         $('#show-interactive').on('click', function(e) {
             e.preventDefault();
-            dislpayPreviewer(configInteractive);
+            displayPreviewer(configInteractive);
         });
 
         $('#show-readonly').on('click', function(e) {
             e.preventDefault();
-            dislpayPreviewer(configReadOnly);
+            displayPreviewer(configReadOnly);
         });
     });
 });

--- a/views/js/test/previewer/component/qtiItem/test.html
+++ b/views/js/test/previewer/component/qtiItem/test.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Item Previewer - qtiItem previewer component</title>
+        <base href="../../../../../../../tao/views/" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <link rel="stylesheet" href="css/tao-main-style.css"/>
+        <link rel="stylesheet" href="css/tao-3.css"/>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="component/qtiItem.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+                requirejs.config({
+                    "config": {
+                        "core/request" : {
+                            'noToken' : true
+                        }
+                    }
+                });
+
+                //load the test
+                require(['taoQtiTestPreviewer/test/previewer/component/qtiItem/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture">
+            <div id="fixture-api"></div>
+            <div id="fixture-render"></div>
+            <div id="fixture-destroy"></div>
+        </div>
+        <div id="visual-test">
+        </div>
+    </body>
+</html>

--- a/views/js/test/previewer/component/qtiItem/test.js
+++ b/views/js/test/previewer/component/qtiItem/test.js
@@ -1,0 +1,255 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018-2019 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'jquery',
+    'lodash',
+    'taoQtiTestPreviewer/previewer/component/qtiItem',
+    'json!taoQtiItem/test/samples/json/space-shuttle.json',
+    'lib/jquery.mockjax/jquery.mockjax',
+    'css!taoQtiTestPreviewer/previewer/provider/item/css/item'
+], function($, _, qtiItemPreviewerFactory, itemData) {
+    'use strict';
+
+    QUnit.module('API');
+
+    // Prevent the AJAX mocks to pollute the logs
+    $.mockjaxSettings.logger = null;
+    $.mockjaxSettings.responseTime = 1;
+
+    // Restore AJAX method after each test
+    QUnit.testDone(function() {
+        $.mockjax.clear();
+    });
+
+    QUnit.test('module', assert =>  {
+        const ready = assert.async();
+        const config = {};
+
+        const previewer1 = qtiItemPreviewerFactory('#fixture-api', config);
+        const previewer2 = qtiItemPreviewerFactory('#fixture-api', config);
+
+        assert.expect(4);
+        $.mockjax({
+            url: '/*',
+            responseText: {
+                success: true
+            }
+        });
+        assert.equal(typeof qtiItemPreviewerFactory, 'function', 'The previewer module exposes a function');
+        assert.equal(typeof previewer1, 'object', 'The previewer factory returns an object');
+        assert.equal(typeof previewer2, 'object', 'The previewer factory returns an object');
+        assert.notEqual(previewer1, previewer2, 'The previewer factory returns a different instance on each call');
+
+        Promise.all([
+            new Promise(resolve => previewer1.on('ready', resolve) ),
+            new Promise(resolve => previewer2.on('ready', resolve) )
+        ]).catch(function(err) {
+            assert.pushResult({
+                result: false,
+                message: err
+            });
+        }).then( ready );
+    });
+
+    QUnit.cases.init([{
+        title: 'itemData in init',
+        mock: {
+            url: '/init*',
+            responseText: {
+                success: true,
+                itemIdentifier: 'item-1',
+                itemData: {
+                    content: {
+                        type: 'qti',
+                        data: itemData
+                    },
+                    baseUrl: '',
+                    state: {}
+                }
+            }
+        }
+    }, {
+        title: 'itemRef in init',
+        mock: [{
+            url: '/init*',
+            responseText: {
+                success: true,
+                itemIdentifier: 'item-2'
+            }
+        }, {
+            url: '/getItem*',
+            responseText: {
+                success: true,
+                content: {
+                    type: 'qti',
+                    data: itemData
+                },
+                baseUrl: '',
+                state: {}
+            }
+        }]
+    }, {
+        title: 'manual load',
+        itemIdentifier: 'item-3',
+        mock: [{
+            url: '/init*',
+            responseText: {
+                success: true
+            }
+        }, {
+            url: '/getItem*',
+            responseText: {
+                success: true,
+                content: {
+                    type: 'qti',
+                    data: itemData
+                },
+                baseUrl: '',
+                state: {}
+            }
+        }]
+    }]).test('render item ', (data, assert) =>  {
+        const ready = assert.async();
+        const $container = $('#fixture-render');
+        const config = {};
+
+        assert.expect(1);
+
+        $.mockjax(data.mock);
+
+        qtiItemPreviewerFactory($container, config)
+            .on('error', function(err) {
+                assert.ok(false, 'An error has occurred');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            })
+            .on('ready', function(runner) {
+                runner
+                    .after('renderitem', function() {
+                        assert.ok(true, 'The previewer has been rendered');
+                        ready();
+                    });
+
+                if (data.itemIdentifier) {
+                    runner.loadItem(data.itemIdentifier);
+                }
+            });
+    });
+
+    QUnit.test('destroy', assert =>  {
+        const ready = assert.async();
+        const $container = $('#fixture-destroy');
+        const config = {};
+
+        assert.expect(2);
+
+        $.mockjax({
+            url: '/init*',
+            responseText: {
+                success: true
+            }
+        });
+
+        qtiItemPreviewerFactory($container, config)
+            .on('error', function(err) {
+                assert.ok(false, 'An error has occurred');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            })
+            .on('ready', function(runner) {
+                assert.equal($container.children().length, 1, 'The previewer has been rendered');
+                runner.destroy();
+            })
+            .after('destroy', function() {
+                assert.equal($container.children().length, 0, 'The previewer has been destroyed');
+                ready();
+            });
+    });
+
+    QUnit.module('Visual');
+
+    QUnit.test('Visual test', function (assert) {
+        const ready = assert.async();
+        const $container = $('#visual-test');
+        const itemRef = 'item-1';
+        const config = {};
+
+        assert.expect(1);
+
+        $.mockjax({
+            url: '/init*',
+            responseText: {
+                success: true
+            }
+        });
+        $.mockjax({
+            url: '/getItem*',
+            responseText: {
+                success: true,
+                content: {
+                    type: 'qti',
+                    data: itemData
+                },
+                baseUrl: '',
+                state: {}
+            }
+        });
+        $.mockjax({
+            url: '/submitItem*',
+            responseText: {
+                success: true,
+                displayFeedbacks: false,
+                itemSession: {
+                    SCORE: {
+                        base: {
+                            float: 0
+                        }
+                    }
+                }
+            }
+        });
+
+        qtiItemPreviewerFactory($container, config)
+            .on('error', function(err) {
+                assert.ok(false, 'An error has occurred');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            })
+            .on('ready', function(runner) {
+                runner
+                    .after('renderitem.runnerComponent', function() {
+                        assert.ok(true, 'The previewer has been rendered');
+                        ready();
+                    })
+                    .loadItem(itemRef);
+            });
+    });
+});

--- a/views/js/test/previewer/component/qtiItem/test.js
+++ b/views/js/test/previewer/component/qtiItem/test.js
@@ -130,7 +130,9 @@ define([
     }]).test('render item ', (data, assert) =>  {
         const ready = assert.async();
         const $container = $('#fixture-render');
-        const config = {};
+        const config = {
+            itemUri: data.itemIdentifier
+        };
 
         assert.expect(1);
 
@@ -146,15 +148,10 @@ define([
                 ready();
             })
             .on('ready', function(runner) {
-                runner
-                    .after('renderitem', function() {
-                        assert.ok(true, 'The previewer has been rendered');
-                        ready();
-                    });
-
-                if (data.itemIdentifier) {
-                    runner.loadItem(data.itemIdentifier);
-                }
+                runner.after('renderitem', function() {
+                    assert.ok(true, 'The previewer has been rendered');
+                    ready();
+                });
             });
     });
 
@@ -196,8 +193,9 @@ define([
     QUnit.test('Visual test', function (assert) {
         const ready = assert.async();
         const $container = $('#visual-test');
-        const itemRef = 'item-1';
-        const config = {};
+        const config = {
+            itemUri: 'item-1'
+        };
 
         assert.expect(1);
 
@@ -244,12 +242,10 @@ define([
                 ready();
             })
             .on('ready', function(runner) {
-                runner
-                    .after('renderitem.runnerComponent', function() {
-                        assert.ok(true, 'The previewer has been rendered');
-                        ready();
-                    })
-                    .loadItem(itemRef);
+                runner.after('renderitem.runnerComponent', function() {
+                    assert.ok(true, 'The previewer has been rendered');
+                    ready();
+                });
             });
     });
 });

--- a/views/js/test/previewer/plugins/controls/close/test.js
+++ b/views/js/test/previewer/plugins/controls/close/test.js
@@ -95,7 +95,7 @@ define([
     QUnit.test('module', assert => {
         const ready = assert.async();
         assert.expect(3);
-        previewerFactory(runnerConfig, $('#fixture-api'))
+        previewerFactory('#fixture-api', runnerConfig)
             .on('ready', function (runner) {
                 assert.equal(typeof pluginFactory, 'function', 'The module exposes a function');
                 assert.equal(typeof pluginFactory(runner), 'object', 'The factory produces an instance');
@@ -125,7 +125,7 @@ define([
         const ready = assert.async();
         assert.expect(1);
 
-        previewerFactory(runnerConfig, $('#fixture-api'))
+        previewerFactory('#fixture-api', runnerConfig)
             .on('ready', function (runner) {
                 const plugin = pluginFactory(runner);
                 assert.equal(typeof plugin[data.title], 'function', `The instances expose a ${data.title} function`);
@@ -140,7 +140,7 @@ define([
         const ready = assert.async();
         assert.expect(3);
 
-        previewerFactory(runnerConfig, $('#fixture-render'))
+        previewerFactory('#fixture-render', runnerConfig)
             .on('ready', function (runner) {
                 const areaBroker = runner.getAreaBroker();
                 const plugin = runner.getPlugin('close');
@@ -170,7 +170,7 @@ define([
         const ready = assert.async();
         assert.expect(7);
 
-        previewerFactory(runnerConfig, $('#fixture-enable'))
+        previewerFactory('#fixture-enable', runnerConfig)
             .on('ready', function (runner) {
                 const areaBroker = runner.getAreaBroker();
                 const plugin = runner.getPlugin('close');
@@ -232,7 +232,7 @@ define([
         const ready = assert.async();
         assert.expect(4);
 
-        previewerFactory(runnerConfig, $('#fixture-show'))
+        previewerFactory('#fixture-show', runnerConfig)
             .on('ready', function (runner) {
                 const areaBroker = runner.getAreaBroker();
                 const plugin = runner.getPlugin('close');
@@ -275,7 +275,7 @@ define([
         const ready = assert.async();
         assert.expect(4);
 
-        previewerFactory(runnerConfig, $('#fixture-close'))
+        previewerFactory('#fixture-close', runnerConfig)
             .on('ready', function (runner) {
                 const areaBroker = runner.getAreaBroker();
                 const plugin = runner.getPlugin('close');
@@ -312,7 +312,7 @@ define([
         const itemRef = 'item-1';
         assert.expect(1);
 
-        previewerFactory(runnerConfig, $container)
+        previewerFactory($container, runnerConfig)
             .on('error', function(err) {
                 assert.ok(false, 'An error has occurred');
                 assert.pushResult({

--- a/views/js/test/previewer/plugins/navigation/submit/test.js
+++ b/views/js/test/previewer/plugins/navigation/submit/test.js
@@ -50,7 +50,7 @@ define([
             proxy: {
                 id: 'qtiItemPreviewProxy',
                 module: 'taoQtiTestPreviewer/previewer/proxy/item',
-                bundle: 'taoQtiTest/loader/qtiTestRunner.min',
+                bundle: 'taoQtiTestPreviewer/loader/qtiPreviewer.min',
                 category: 'proxy'
             },
             communicator: {
@@ -112,7 +112,7 @@ define([
         const ready = assert.async();
         assert.expect(3);
 
-        previewerFactory(runnerConfig, $('#fixture-api'))
+        previewerFactory('#fixture-api', runnerConfig)
             .on('ready', function (runner) {
                 assert.equal(typeof pluginFactory, 'function', 'The module exposes a function');
                 assert.equal(typeof pluginFactory(runner), 'object', 'The factory produces an instance');
@@ -141,7 +141,7 @@ define([
     ]).test('plugin API ', (data, assert) =>  {
         const ready = assert.async();
         assert.expect(1);
-        previewerFactory(runnerConfig, $('#fixture-api'))
+        previewerFactory('#fixture-api', runnerConfig)
             .on('ready', function (runner) {
                 const plugin = pluginFactory(runner);
                 assert.equal(typeof plugin[data.title], 'function', `The instances expose a ${data.title} function`);
@@ -169,7 +169,7 @@ define([
         const config = Object.assign({}, runnerConfig);
         config.options = data.options;
 
-        previewerFactory(config, $('#fixture-render'))
+        previewerFactory('#fixture-render', config)
             .on('ready', function (runner) {
                 const areaBroker = runner.getAreaBroker();
                 const plugin = runner.getPlugin('submit');
@@ -210,7 +210,7 @@ define([
         const ready = assert.async();
         assert.expect(11);
 
-        previewerFactory(runnerConfig, $('#fixture-enable'))
+        previewerFactory('#fixture-enable', runnerConfig)
             .on('ready', function (runner) {
                 const areaBroker = runner.getAreaBroker();
                 const plugin = runner.getPlugin('submit');
@@ -282,7 +282,7 @@ define([
         const ready = assert.async();
         assert.expect(17);
 
-        previewerFactory(runnerConfig, $('#fixture-show'))
+        previewerFactory('#fixture-show', runnerConfig)
             .on('ready', function (runner) {
                 const areaBroker = runner.getAreaBroker();
                 const plugin = runner.getPlugin('submit');
@@ -373,7 +373,7 @@ define([
     QUnit.test('submit', assert =>  {
         const ready = assert.async();
         assert.expect(14);
-        previewerFactory(runnerConfig, $('#fixture-show'))
+        previewerFactory('#fixture-show', runnerConfig)
             .on('ready', function (runner) {
                 const areaBroker = runner.getAreaBroker();
                 const plugin = runner.getPlugin('submit');
@@ -459,7 +459,7 @@ define([
 
         assert.expect(1);
 
-        previewerFactory(runnerConfig, $container)
+        previewerFactory($container, runnerConfig)
             .on('error', function(err) {
                 assert.ok(false, 'An error has occurred');
                 assert.pushResult({

--- a/views/js/test/previewer/plugins/tools/scale/plugin/test.js
+++ b/views/js/test/previewer/plugins/tools/scale/plugin/test.js
@@ -99,7 +99,7 @@ define([
         const ready = assert.async();
         assert.expect(3);
 
-        previewerFactory(runnerConfig, $('#fixture-api'))
+        previewerFactory('#fixture-api', runnerConfig)
             .on('ready', function (runner) {
                 assert.equal(typeof pluginFactory, 'function', 'The module exposes a function');
                 assert.equal(typeof pluginFactory(runner), 'object', 'The factory produces an instance');
@@ -129,7 +129,7 @@ define([
         const ready = assert.async();
         assert.expect(1);
 
-        previewerFactory(runnerConfig, $('#fixture-api'))
+        previewerFactory('#fixture-api', runnerConfig)
             .on('ready', function (runner) {
                 const plugin = pluginFactory(runner);
                 assert.equal(typeof plugin[data.title], 'function', `The instances expose a ${data.title} function`);
@@ -157,7 +157,7 @@ define([
         const config = Object.assign({}, runnerConfig);
         config.options = data.options;
 
-        previewerFactory(config, $('#fixture-render'))
+        previewerFactory('#fixture-render', config)
             .on('ready', function (runner) {
                 const areaBroker = runner.getAreaBroker();
                 const plugin = runner.getPlugin('scale');
@@ -188,7 +188,7 @@ define([
         const ready = assert.async();
         assert.expect(7);
 
-        previewerFactory(runnerConfig, $('#fixture-enable'))
+        previewerFactory('#fixture-enable', runnerConfig)
             .on('ready', function (runner) {
                 const areaBroker = runner.getAreaBroker();
                 const plugin = runner.getPlugin('scale');
@@ -250,7 +250,7 @@ define([
         const ready = assert.async();
         assert.expect(10);
 
-        previewerFactory(runnerConfig, $('#fixture-show'))
+        previewerFactory('#fixture-show', runnerConfig)
             .on('ready', function (runner) {
                 const areaBroker = runner.getAreaBroker();
                 const plugin = runner.getPlugin('scale');
@@ -306,7 +306,7 @@ define([
         const ready = assert.async();
         assert.expect(32);
 
-        previewerFactory(runnerConfig, $('#fixture-show'))
+        previewerFactory('#fixture-scale', runnerConfig)
             .on('ready', function (runner) {
                 const areaBroker = runner.getAreaBroker();
                 const plugin = runner.getPlugin('scale');
@@ -449,7 +449,7 @@ define([
         const itemRef = 'item-1';
         assert.expect(1);
 
-        previewerFactory(runnerConfig, $container)
+        previewerFactory($container, runnerConfig)
             .on('error', function(err) {
                 assert.ok(false, 'An error has occurred');
                 assert.pushResult({

--- a/views/js/test/previewer/runner/test.js
+++ b/views/js/test/previewer/runner/test.js
@@ -69,8 +69,8 @@ define([
             options : {}
         };
 
-        const previewer1 = previewerFactory(config, $('#fixture-1'));
-        const previewer2 = previewerFactory(config, $('#fixture-2'));
+        const previewer1 = previewerFactory('#fixture-1', config);
+        const previewer2 = previewerFactory('#fixture-2', config);
 
         assert.expect(4);
         $.mockjax({
@@ -169,7 +169,7 @@ define([
 
         $.mockjax(data.mock);
 
-        previewerFactory(config, $container)
+        previewerFactory($container, config)
             .on('error', function(err) {
                 assert.ok(false, 'An error has occurred');
                 assert.pushResult({
@@ -210,7 +210,7 @@ define([
             }
         });
 
-        previewerFactory(config, $container)
+        previewerFactory($container, config)
             .on('error', function(err) {
                 assert.ok(false, 'An error has occurred');
                 assert.pushResult({
@@ -296,7 +296,7 @@ define([
             }
         });
 
-        previewerFactory(config, $container)
+        previewerFactory($container, config)
             .on('error', function(err) {
                 assert.ok(false, 'An error has occurred');
                 assert.pushResult({


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8191

Requires: 
 - [x] https://github.com/oat-sa/tao-core/pull/2204

Rework the item previewer in order to be able to use it as a component. The new component setups the proper list of providers, so it can be used directly. The item adapter now uses it, adding the list of plugins to apply.
Also fix the wrong signature of the main factory: the order of parameters was reversed compared to the usual order.

Impacted unit tests:
- `/taoQtiTestPreviewer/views/js/test/previewer/adapter/qtiItem/test.html`
- `/taoQtiTestPreviewer/views/js/test/previewer/component/qtiItem/test.html`
- `/taoQtiTestPreviewer/views/js/test/previewer/runner/test.html`
- `/taoQtiTestPreviewer/views/js/test/previewer/plugins/controls/close/test.html`
- `/taoQtiTestPreviewer/views/js/test/previewer/plugins/navigation/submit/test.html`
- `/taoQtiTestPreviewer/views/js/test/previewer/plugins/tools/scale/plugin/test.html`

To test it:
```
cd tao/views/build
npx grunt connect:test taoqtitestpreviewertest
```

Or in the results screen of TAO, try to review an item.