### PR TITLE
Feature/tao 8191/configurable submit plugin

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return [
     'label' => 'extension-tao-testqti-previewer',
     'description' => 'extension that provides QTI test previewer',
     'license'     => 'GPL-2.0',
-    'version' => '2.4.0',
+    'version' => '2.5.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao'          => '>=37.6.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -87,6 +87,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.2.0');
         }
 
-        $this->skip('0.2.0', '2.4.0');
+        $this->skip('0.2.0', '2.5.0');
     }
 }

--- a/views/js/previewer/component/qtiItem.js
+++ b/views/js/previewer/component/qtiItem.js
@@ -32,6 +32,7 @@ define([
      * @param {String} [config.itemUri] - The URI of the item to load
      * @param {Object} [config.itemState] - The state of the item when relevant
      * @param {Object[]} [config.plugins] - Additional plugins to load
+     * @param {Object[]} [config.pluginsOptions] - Options for the plugins
      * @param {String} [config.fullPage] - Force the previewer to occupy the full window.
      * @param {String} [config.readOnly] - Do not allow to modify the previewed item.
      * @param {Function} [template] - An optional template for the component
@@ -65,7 +66,8 @@ define([
             },
             options: {
                 readOnly: config.readOnly,
-                fullPage: config.fullPage
+                fullPage: config.fullPage,
+                plugins: config.pluginsOptions
             }
         };
 

--- a/views/js/previewer/plugins/navigation/submit/submit.js
+++ b/views/js/previewer/plugins/navigation/submit/submit.js
@@ -52,6 +52,15 @@ define([
 ) {
     'use strict';
 
+    /**
+     * Some default config for the plugin
+     * @type {Object}
+     */
+    const defaults = {
+        submitTitle: __('Submit and show the result'),
+        submitText: __('Submit')
+    };
+
     return pluginFactory({
 
         name: 'submit',
@@ -59,71 +68,71 @@ define([
         /**
          * Initialize the plugin (called during runner's init)
          */
-        init: function init() {
-            var self = this;
-            var testRunner = this.getTestRunner();
+        init() {
+            const testRunner = this.getTestRunner();
+            const pluginConfig = _.defaults(this.getConfig(), defaults);
 
             /**
              * Tells if the component is enabled
              * @returns {Boolean}
              */
-            function isPluginAllowed() {
-                var config = testRunner.getConfig();
+            const isPluginAllowed = () => {
+                const config = testRunner.getConfig();
                 return !config.options.readOnly;
-            }
+            };
 
             // display the console and its related controls, then auto scrolls to the last element
-            function showConsole() {
-                hider.show(self.controls.$console);
-                hider.show(self.controls.$consoleBody);
-                hider.show(self.controls.$consoleCloser);
-                autoscroll(self.controls.$consoleBody.children().last(), self.controls.$consoleBody);
-            }
+            const showConsole = () => {
+                hider.show(this.controls.$console);
+                hider.show(this.controls.$consoleBody);
+                hider.show(this.controls.$consoleCloser);
+                autoscroll(this.controls.$consoleBody.children().last(), this.controls.$consoleBody);
+            };
 
             // hide the console and its related controls
-            function hideConsole() {
-                hider.hide(self.controls.$console);
-                hider.hide(self.controls.$consoleCloser);
-            }
+            const hideConsole = () => {
+                hider.hide(this.controls.$console);
+                hider.hide(this.controls.$consoleCloser);
+            };
 
             // add a line to the console
-            function addConsoleLine(type, message) {
-                var data = {
+            const addConsoleLine = (type, message) => {
+                const data = {
                     time: strPad(moment().format('HH:mm:ss'), 12, ' '),
                     type: strPad(type || '', 18, ' '),
                     message: strPad(message || '', 18, ' ')
                 };
-                self.controls.$consoleBody.append($(consoleLineTpl(data)));
-            }
+                this.controls.$consoleBody.append($(consoleLineTpl(data)));
+            };
 
             // display responses in the console
-            function showResponses(type, responses) {
-                _.forEach(responses, function (response, identifier) {
-                    addConsoleLine(type, strPad(identifier + ': ', 15, ' ') + _.escape(pciResponse.prettyPrint(response)));
+            const showResponses = (type, responses) => {
+                _.forEach(responses, (response, identifier) => {
+                    addConsoleLine(type, strPad(`${identifier}: `, 15, ' ') + _.escape(pciResponse.prettyPrint(response)));
                 });
-            }
+            };
 
             this.controls = {
                 $button: $(buttonTpl({
                     control: 'submit',
-                    title: __('Submit and show the result'),
+                    title: pluginConfig.submitTitle,
                     icon: 'forward',
-                    text: __('Submit')
+                    text: pluginConfig.submitText
                 })),
                 $console: $(consoleTpl()),
                 $consoleCloser: $(consoleCloserTpl())
             };
             this.controls.$consoleBody = this.controls.$console.find('.preview-console-body');
 
-            this.controls.$button.on('click', function (e) {
+            this.controls.$button.on('click', e => {
                 e.preventDefault();
-                if (self.getState('enabled') !== false) {
-                    self.disable();
+                if (this.getState('enabled') !== false) {
+                    this.disable();
                     testRunner.trigger('submititem');
                 }
             });
 
-            this.controls.$consoleCloser.on('click', function (e) {
+            this.controls.$consoleCloser.on('click', e => {
                 e.preventDefault();
                 hideConsole();
             });
@@ -135,39 +144,38 @@ define([
             this.disable();
 
             testRunner
-                .on('render', function () {
+                .on('render', () => {
                     if (isPluginAllowed()) {
-                        self.show();
+                        this.show();
                     } else {
-                        self.hide();
+                        this.hide();
                     }
                 })
-                .on('submitresponse', function (responses) {
+                .on('submitresponse', responses => {
                     showResponses(__('Submitted data'), responses);
                     showConsole();
                 })
-                .on('scoreitem', function (responses) {
+                .on('scoreitem', responses => {
                     if (responses.itemSession) {
                         showResponses(__('Output data'), responses.itemSession);
                         showConsole();
                     }
                 })
-                .on('enablenav', function () {
-                    self.enable();
+                .on('enablenav', () => {
+                    this.enable();
                 })
-                .on('disablenav', function () {
-                    self.disable();
+                .on('disablenav', () => {
+                    this.disable();
                 });
         },
 
         /**
          * Called during the runner's render phase
          */
-        render: function render() {
-
+        render() {
             //attach the element to the navigation area
-            var $container = this.getAreaBroker().getContainer();
-            var $navigation = this.getAreaBroker().getNavigationArea();
+            const $container = this.getAreaBroker().getContainer();
+            const $navigation = this.getAreaBroker().getNavigationArea();
             $navigation.append(this.controls.$button);
             $navigation.append(this.controls.$consoleCloser);
             $container.append(this.controls.$console);
@@ -176,38 +184,40 @@ define([
         /**
          * Called during the runner's destroy phase
          */
-        destroy: function destroy() {
-            _.forEach(this.controls, function ($el) {
-                $el.remove();
-            });
+        destroy() {
+            _.forEach(this.controls, $el => $el.remove());
             this.controls = null;
         },
 
         /**
          * Enable the button
          */
-        enable: function enable() {
-            this.controls.$button.removeProp('disabled').removeClass('disabled');
+        enable() {
+            this.controls.$button
+                .removeProp('disabled')
+                .removeClass('disabled');
         },
 
         /**
          * Disable the button
          */
-        disable: function disable() {
-            this.controls.$button.prop('disabled', true).addClass('disabled');
+        disable() {
+            this.controls.$button
+                .prop('disabled', true)
+                .addClass('disabled');
         },
 
         /**
          * Show the button
          */
-        show: function show() {
+        show() {
             hider.show(this.controls.$button);
         },
 
         /**
          * Hide the button
          */
-        hide: function hide() {
+        hide() {
             _.forEach(this.controls, hider.hide);
         }
     });

--- a/views/js/previewer/provider/item/item.js
+++ b/views/js/previewer/provider/item/item.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2018-2019 (original work) Open Assessment Technologies SA ;
  */
 
 /**
@@ -96,6 +96,23 @@ define([
             //the test run needs to be identified uniquely
             const identifier = config.serviceCallId || `test-${Date.now()}`;
             return testStoreFactory(identifier);
+        },
+
+        /**
+         * Installation of the provider, called during test runner init phase.
+         */
+        install() {
+            const {plugins} = this.getConfig().options;
+            if (plugins) {
+                _.forEach(this.getPlugins(), plugin => {
+                    if (_.isPlainObject(plugin) && _.isFunction(plugin.setConfig)) {
+                        const config = plugins[plugin.getName()];
+                        if (_.isPlainObject(config)) {
+                            plugin.setConfig(config);
+                        }
+                    }
+                });
+            }
         },
 
         /**

--- a/views/js/test/previewer/component/qtiItem/test.js
+++ b/views/js/test/previewer/component/qtiItem/test.js
@@ -24,8 +24,7 @@ define([
     'lodash',
     'taoQtiTestPreviewer/previewer/component/qtiItem',
     'json!taoQtiItem/test/samples/json/space-shuttle.json',
-    'lib/jquery.mockjax/jquery.mockjax',
-    'css!taoQtiTestPreviewer/previewer/provider/item/css/item'
+    'lib/jquery.mockjax/jquery.mockjax'
 ], function($, _, qtiItemPreviewerFactory, itemData) {
     'use strict';
 

--- a/views/js/test/previewer/plugins/navigation/submit/test.js
+++ b/views/js/test/previewer/plugins/navigation/submit/test.js
@@ -22,6 +22,7 @@
 define([
     'jquery',
     'lodash',
+    'i18n',
     'ui/hider',
     'taoQtiTestPreviewer/previewer/runner',
     'taoQtiTestPreviewer/previewer/plugins/navigation/submit/submit',
@@ -31,6 +32,7 @@ define([
 ], function (
     $,
     _,
+    __,
     hider,
     previewerFactory,
     pluginFactory,
@@ -154,17 +156,34 @@ define([
 
     QUnit.cases.init([{
         title: 'interactive',
+        expectedTitle: __('Submit and show the result'),
+        expectedText: __('Submit'),
         options: {
             readOnly: false
         }
     }, {
         title: 'read only',
+        expectedTitle: __('Submit and show the result'),
+        expectedText: __('Submit'),
         options: {
             readOnly: true
         }
+    }, {
+        title: 'custom',
+        expectedTitle: 'Foo',
+        expectedText: 'Bar',
+        options: {
+            readOnly: true,
+            plugins: {
+                submit: {
+                    submitTitle: 'Foo',
+                    submitText: 'Bar',
+                }
+            }
+        }
     }]).test('render / destroy ', (data, assert) =>  {
         const ready = assert.async();
-        assert.expect(8);
+        assert.expect(10);
 
         const config = Object.assign({}, runnerConfig);
         config.options = data.options;
@@ -183,6 +202,8 @@ define([
                         assert.equal($button.length, 1, 'The button has been inserted');
                         assert.equal($closer.length, 1, 'The console closer has been inserted');
                         assert.equal($console.length, 1, 'The console has been inserted');
+                        assert.equal($button.attr('title').trim(), data.expectedTitle, 'The button has the expected title');
+                        assert.equal($button.text().trim(), data.expectedText, 'The button has the expected text');
                         assert.equal($button.hasClass('disabled'), true, 'The button has been rendered disabled');
                         assert.equal(hider.isHidden($button), config.options.readOnly, 'The button state is aligned to the config');
                         return plugin.destroy();

--- a/views/js/test/previewer/plugins/navigation/submit/test.js
+++ b/views/js/test/previewer/plugins/navigation/submit/test.js
@@ -173,7 +173,7 @@ define([
         expectedTitle: 'Foo',
         expectedText: 'Bar',
         options: {
-            readOnly: true,
+            readOnly: false,
             plugins: {
                 submit: {
                     submitTitle: 'Foo',


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8191

Add the ability to configure the plugins in the `qtiItem` previewer. Especially, allows to configure the button labels of the submit plugin.

To configure the `submit` button when using the `qtiItem` component:
```javascript
qtiItemPreviewerFactory(container, {
    readOnly: false,
    pluginsOptions: {
        submit: {
            submitTitle: 'Foo',
            submitText: 'Bar',
        }
    }
});
```

Or when using the main factory:
```javascript
previewerFactory(container, {
    options: {
        readOnly: true,
        plugins: {
           submit: {
               submitTitle: 'Foo',
               submitText: 'Bar',
           }
        }
    }
});
```

The `qtiItem` provider has also been updated to ES6.

Impacted unit tests:
- `/taoQtiTestPreviewer/views/js/test/previewer/plugins/navigation/submit/test.html`
- `/taoQtiTestPreviewer/views/js/test/previewer/adapter/qtiItem/test.html`
- `/taoQtiTestPreviewer/views/js/test/previewer/component/qtiItem/test.html`
- `/taoQtiTestPreviewer/views/js/test/previewer/runner/test.html`

To test it:
```
cd tao/views/build
npx grunt connect:test taoqtitestpreviewertest
```
