### PR TITLE
Feature/tao 8753/configure submit icon

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return [
     'label' => 'extension-tao-testqti-previewer',
     'description' => 'extension that provides QTI test previewer',
     'license'     => 'GPL-2.0',
-    'version' => '2.6.0',
+    'version' => '2.7.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao'          => '>=37.6.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -87,6 +87,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.2.0');
         }
 
-        $this->skip('0.2.0', '2.6.0');
+        $this->skip('0.2.0', '2.7.0');
     }
 }

--- a/views/js/previewer/plugins/navigation/submit/submit.js
+++ b/views/js/previewer/plugins/navigation/submit/submit.js
@@ -58,7 +58,8 @@ define([
      */
     const defaults = {
         submitTitle: __('Submit and show the result'),
-        submitText: __('Submit')
+        submitText: __('Submit'),
+        submitIcon: 'forward'
     };
 
     return pluginFactory({
@@ -116,7 +117,7 @@ define([
                 $button: $(buttonTpl({
                     control: 'submit',
                     title: pluginConfig.submitTitle,
-                    icon: 'forward',
+                    icon: pluginConfig.submitIcon,
                     text: pluginConfig.submitText
                 })),
                 $console: $(consoleTpl()),

--- a/views/js/test/previewer/plugins/navigation/submit/test.js
+++ b/views/js/test/previewer/plugins/navigation/submit/test.js
@@ -158,6 +158,7 @@ define([
         title: 'interactive',
         expectedTitle: __('Submit and show the result'),
         expectedText: __('Submit'),
+        expectedIcon: 'forward',
         options: {
             readOnly: false
         }
@@ -165,6 +166,7 @@ define([
         title: 'read only',
         expectedTitle: __('Submit and show the result'),
         expectedText: __('Submit'),
+        expectedIcon: 'forward',
         options: {
             readOnly: true
         }
@@ -172,18 +174,20 @@ define([
         title: 'custom',
         expectedTitle: 'Foo',
         expectedText: 'Bar',
+        expectedIcon: 'globe',
         options: {
             readOnly: false,
             plugins: {
                 submit: {
                     submitTitle: 'Foo',
                     submitText: 'Bar',
+                    submitIcon: 'globe'
                 }
             }
         }
     }]).test('render / destroy ', (data, assert) =>  {
         const ready = assert.async();
-        assert.expect(10);
+        assert.expect(11);
 
         const config = Object.assign({}, runnerConfig);
         config.options = data.options;
@@ -204,6 +208,7 @@ define([
                         assert.equal($console.length, 1, 'The console has been inserted');
                         assert.equal($button.attr('title').trim(), data.expectedTitle, 'The button has the expected title');
                         assert.equal($button.text().trim(), data.expectedText, 'The button has the expected text');
+                        assert.equal($button.find(`.icon-${data.expectedIcon}`).length, 1, 'The button has the expected icon');
                         assert.equal($button.hasClass('disabled'), true, 'The button has been rendered disabled');
                         assert.equal(hider.isHidden($button), config.options.readOnly, 'The button state is aligned to the config');
                         return plugin.destroy();


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8753

Make the icon configurable for the submit button in the `submit` plugin.

Impacted unit test: `/taoQtiTestPreviewer/views/js/test/previewer/plugins/navigation/submit/test.html`

To run the tests:
```
cd tao/views/build
npx grunt connect:dev taoqtitestpreviewertest
```