### PR TITLE
Feature/tao 8942 fetch correct item responses

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return [
     'label' => 'extension-tao-testqti-previewer',
     'description' => 'extension that provides QTI test previewer',
     'license'     => 'GPL-2.0',
-    'version' => '2.7.0',
+    'version' => '2.8.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao'          => '>=37.6.0',

--- a/models/ItemPreviewer.php
+++ b/models/ItemPreviewer.php
@@ -177,7 +177,13 @@ class ItemPreviewer implements ServiceLocatorAwareInterface
             throw new common_exception_NotFound('File variableElements.json should exist');
         }
 
-        return json_decode($variableElements->read(), true);
+        $variablesData = json_decode($variableElements->read(), true);
+
+        $variablesData = array_filter($variablesData, static function ($key) {
+            return false === strpos($key, 'response_templatesdriven_');
+        }, ARRAY_FILTER_USE_KEY);
+
+        return $variablesData;
     }
 
     /**

--- a/models/ItemPreviewer.php
+++ b/models/ItemPreviewer.php
@@ -19,6 +19,8 @@
 
 namespace oat\taoQtiTestPreviewer\models;
 
+use common_exception_InconsistentData;
+use common_exception_NotFound;
 use oat\taoDelivery\model\RuntimeService;
 use oat\taoItems\model\pack\ItemPack;
 use oat\taoItems\model\pack\Packer;
@@ -115,6 +117,16 @@ class ItemPreviewer implements ServiceLocatorAwareInterface
         return $this;
     }
 
+    private function validateProperties()
+    {
+        if (empty($this->userLanguage)
+            || empty($this->itemDefinition)
+            || empty($this->delivery)
+        ) {
+            throw new \LogicException('UserLanguage, ItemDefiniton and Delivery are mandatory for loading of compiled item data');
+        }
+    }
+
     /**
      * @return array
      *
@@ -125,9 +137,7 @@ class ItemPreviewer implements ServiceLocatorAwareInterface
      */
     public function loadCompiledItemData()
     {
-        if (empty($this->userLanguage) || empty($this->itemDefinition) || empty($this->delivery)) {
-            throw new \LogicException('UserLanguage, ItemDefiniton and Delivery are mandatory for loading of compiled item data');
-        }
+        $this->validateProperties();
 
         $jsonFile = $this->getItemPrivateDir()->getFile($this->userLanguage . DIRECTORY_SEPARATOR . QtiJsonItemCompiler::ITEM_FILE_NAME);
         $xmlFile = $this->getItemPrivateDir()->getFile($this->userLanguage . DIRECTORY_SEPARATOR . Service::QTI_ITEM_FILE);
@@ -146,10 +156,28 @@ class ItemPreviewer implements ServiceLocatorAwareInterface
 
             $itemData = $itemPack->JsonSerialize();
         } else {
-            throw new \common_exception_NotFound('Either item.json or qti.xml should exist');
+            throw new common_exception_NotFound('Either item.json or qti.xml should exist');
         }
 
         return $itemData;
+    }
+
+    /**
+     * @return mixed
+     * @throws common_exception_InconsistentData
+     * @throws common_exception_NotFound
+     */
+    public function loadCompiledItemVariables()
+    {
+        $this->validateProperties();
+
+        $variableElements = $this->getItemPrivateDir()->getFile($this->userLanguage . DIRECTORY_SEPARATOR . QtiJsonItemCompiler::VAR_ELT_FILE_NAME);
+
+        if (!$variableElements->exists()) {
+            throw new common_exception_NotFound('File variableElements.json should exist');
+        }
+
+        return json_decode($variableElements->read(), true);
     }
 
     /**

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -87,6 +87,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.2.0');
         }
 
-        $this->skip('0.2.0', '2.7.0');
+        $this->skip('0.2.0', '2.8.0');
     }
 }


### PR DESCRIPTION
Task is https://oat-sa.atlassian.net/browse/TAO-8942

These changes introduce a new method for getting compiled proper responses for each item.
In the `item.json` correct responses skipped and need to fetch them from another file that is solved here.