### PR TITLE
Fix/tao 8942/improve filtering of variables

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return [
     'label' => 'extension-tao-testqti-previewer',
     'description' => 'extension that provides QTI test previewer',
     'license'     => 'GPL-2.0',
-    'version' => '2.8.0',
+    'version' => '2.8.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao'          => '>=37.6.0',

--- a/models/ItemPreviewer.php
+++ b/models/ItemPreviewer.php
@@ -179,8 +179,9 @@ class ItemPreviewer implements ServiceLocatorAwareInterface
 
         $variablesData = json_decode($variableElements->read(), true);
 
-        $variablesData = array_filter($variablesData, static function ($key) {
-            return false === strpos($key, 'response_templatesdriven_');
+        // make sure the variables data are compliant to QTI definition
+        $variablesData = array_filter($variablesData, static function ($key) use ($variablesData) {
+            return array_key_exists('qtiClass', $variablesData[$key]) && array_key_exists('serial', $variablesData[$key]);
         }, ARRAY_FILTER_USE_KEY);
 
         return $variablesData;

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -87,6 +87,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.2.0');
         }
 
-        $this->skip('0.2.0', '2.8.0');
+        $this->skip('0.2.0', '2.8.1');
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8942

Improve the filtering of variables data in order to discard entries that don't contain QTI expected properties.

The issue was the `responseRules` were added aside the responses declaration breaking the item runner.

<img width="393" alt="image" src="https://user-images.githubusercontent.com/1500098/64949408-65ad2800-d879-11e9-9677-008b2b8f734d.png">
