### PR TITLE
Make data language to have precedence over tt language if set

### DIFF
--- a/models/GenerisUserService.php
+++ b/models/GenerisUserService.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\taoQtiTestPreviewer\models;
+
+use common_exception_Error;
+use core_kernel_users_GenerisUser as GenerisUser;
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\service\ConfigurableService;
+use oat\taoResultServer\models\classes\implementation\ResultServerService;
+
+class GenerisUserService extends ConfigurableService
+{
+    use OntologyAwareTrait;
+
+    /**
+     * @param $deliveryUri
+     * @param $resultId
+     * @return GenerisUser
+     *
+     * @throws common_exception_Error
+     */
+    public function getGenerisUser($deliveryUri, $resultId)
+    {
+        /** @var ResultServerService $resultServerService */
+        $resultServerService = $this->getServiceLocator()->get(ResultServerService::SERVICE_ID);
+
+        $resultStorage = $resultServerService->getResultStorage($deliveryUri);
+
+        $testTakerResult = $resultStorage->getTestTaker($resultId);
+
+        $testTakerResource = $this->getResource($testTakerResult);
+
+        return new GenerisUser($testTakerResource);
+    }
+}

--- a/models/PreviewLanguageService.php
+++ b/models/PreviewLanguageService.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\taoQtiTestPreviewer\models;
+
+use common_exception_Error;
+use oat\generis\model\GenerisRdf;
+use oat\oatbox\service\ConfigurableService;
+use oat\oatbox\user\UserLanguageService;
+
+class PreviewLanguageService extends ConfigurableService
+{
+    /**
+     * @param string $deliveryUri
+     * @param string $resultId
+     * @return string
+     *
+     * @throws common_exception_Error
+     */
+    public function getPreviewLanguage($deliveryUri, $resultId)
+    {
+        /** @var UserLanguageService $userLanguageService */
+        $userLanguageService = $this->getServiceLocator()->get(UserLanguageService::class);
+
+        if ($userLanguageService->isDataLanguageEnabled()) {
+            return $userLanguageService->getDefaultLanguage();
+        }
+
+        $ttLanguage = $this->getTestTakerInterfaceLanguage($deliveryUri, $resultId);
+
+        return !empty($ttLanguage) ? $ttLanguage : $userLanguageService->getDefaultLanguage();
+    }
+
+    /**
+     * @param string $deliveryUri
+     * @param string $resultId
+     * @return string|null
+     *
+     * @throws common_exception_Error
+     */
+    private function getTestTakerInterfaceLanguage($deliveryUri, $resultId)
+    {
+        /** @var GenerisUserService $generisUserService */
+        $generisUserService = $this->getServiceLocator()->get(GenerisUserService::class);
+
+        $testTaker = $generisUserService->getGenerisUser($deliveryUri, $resultId);
+
+        $languages = $testTaker->getPropertyValues(GenerisRdf::PROPERTY_USER_DEFLG);
+
+        return !empty($languages) ? current($languages) : null;
+    }
+}

--- a/test/unit/models/PreviewLanguageServiceTest.php
+++ b/test/unit/models/PreviewLanguageServiceTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\taoQtiTestPreviewer\test\unit\models;
+
+use core_kernel_users_GenerisUser;
+use oat\generis\model\GenerisRdf;
+use oat\generis\test\MockObject;
+use oat\generis\test\TestCase;
+use oat\oatbox\user\UserLanguageService;
+use oat\taoQtiTestPreviewer\models\GenerisUserService;
+use oat\taoQtiTestPreviewer\models\PreviewLanguageService;
+
+class PreviewLanguageServiceTest extends TestCase
+{
+    /** @var UserLanguageService|MockObject  */
+    private $userLanguageServiceMock;
+
+    /** * @var GenerisUserService|MockObject */
+    private $generisUserServiceMock;
+
+    /** * @var PreviewLanguageService */
+    private $subject;
+
+    protected function setUp()
+    {
+        $this->userLanguageServiceMock = $this->createMock(UserLanguageService::class);
+        $this->generisUserServiceMock = $this->createMock(GenerisUserService::class);
+
+        $this->subject = new PreviewLanguageService();
+        $this->subject->setServiceLocator($this->getServiceLocator());
+    }
+
+    public function testItReturnsDataLanguageIfItEnabled()
+    {
+        $this->userLanguageServiceMock
+            ->expects($this->once())
+            ->method('isDataLanguageEnabled')
+            ->willReturn(true);
+
+        $this->userLanguageServiceMock
+            ->expects($this->once())
+            ->method('getDefaultLanguage')
+            ->willReturn('default-LANG');
+
+        $this->assertSame('default-LANG', $this->subject->getPreviewLanguage('deliveryUri', 'resultId'));
+    }
+
+    public function testItReturnsUserInterfaceLanguageIfDataLanguageDisabled()
+    {
+        $this->userLanguageServiceMock
+            ->expects($this->once())
+            ->method('isDataLanguageEnabled')
+            ->willReturn(false);
+
+        $this->userLanguageServiceMock
+            ->expects($this->never())
+            ->method('getDefaultLanguage');
+
+        $this->setTestTakerInterfaceLanguages(['tt-LANG'], 'resultId', 'deliveryUri');
+
+        $this->assertSame('tt-LANG', $this->subject->getPreviewLanguage('deliveryUri', 'resultId'));
+    }
+
+    public function testItReturnsDefaultLanguageIfNoUserInterfaceLanguageSet()
+    {
+        $this->userLanguageServiceMock
+            ->expects($this->once())
+            ->method('isDataLanguageEnabled')
+            ->willReturn(false);
+
+        $this->setTestTakerInterfaceLanguages([], 'resultId', 'deliveryUri');
+
+        $this->userLanguageServiceMock
+            ->expects($this->once())
+            ->method('getDefaultLanguage')
+            ->willReturn('default-LANG');
+
+        $this->assertSame('default-LANG', $this->subject->getPreviewLanguage('deliveryUri', 'resultId'));
+    }
+
+    private function setTestTakerInterfaceLanguages($languages, $resultId, $deliveryUri)
+    {
+        $generisUserMock = $this->createMock(core_kernel_users_GenerisUser::class);
+
+        $generisUserMock
+            ->expects($this->once())
+            ->method('getPropertyValues')
+            ->with(GenerisRdf::PROPERTY_USER_DEFLG)
+            ->willReturn($languages);
+
+        $this->generisUserServiceMock
+            ->expects($this->once())
+            ->method('getGenerisUser')
+            ->with($deliveryUri, $resultId)
+            ->willReturn($generisUserMock);
+    }
+
+    private function getServiceLocator()
+    {
+        return $this->getServiceLocatorMock([
+            UserLanguageService::class => $this->userLanguageServiceMock,
+            GenerisUserService::class => $this->generisUserServiceMock
+        ]);
+    }
+}


### PR DESCRIPTION
Make item previewer to use data language if it enabled in TAO config.

https://oat-sa.atlassian.net/browse/MS-107

How to test:
1. Go to config/generis/UserLanguageService.conf.php and set value of `lock_data_language` to `false`
2. Login into TAO as admin
3. Create delivery, create test taker with interface language different from English
4. Give the test by that test taker
5. Login back to TAO, on the results page you will be able to review item after hitting review button 
![image](https://user-images.githubusercontent.com/8036983/74745360-d4514000-5274-11ea-9bbd-4293014c419a.png)

