### PR TITLE
Fix TAO-10080 restore context after item preview

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return [
     'label' => 'extension-tao-testqti-previewer',
     'description' => 'extension that provides QTI test previewer',
     'license'     => 'GPL-2.0',
-    'version' => '2.15.1',
+    'version' => '2.15.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'generis'      => '>=12.15.0',

--- a/views/js/previewer/provider/item/item.js
+++ b/views/js/previewer/provider/item/item.js
@@ -59,7 +59,7 @@ define([
     //store the current execution context of the common renderer (preview)
     let _$previousContext = null;
     function setContext($context){
-        _$previousContext = $context;
+        _$previousContext = containerHelper.getContext();
         containerHelper.setContext($context);
     }
     function restoreContext(){
@@ -332,15 +332,15 @@ define([
 
             // prevent the item to be displayed while test runner is destroying
             if (this.itemRunner) {
-                this.itemRunner.clear();
+                this.itemRunner
+                    .on('clear', restoreContext)
+                    .clear();
             }
             this.itemRunner = null;
 
             if (areaBroker) {
                 areaBroker.getToolbox().destroy();
             }
-
-            restoreContext();
         }
     };
 });


### PR DESCRIPTION
- [TAO-10080](https://oat-sa.atlassian.net/browse/TAO-10080) fix: wait for `itemRunner.clear()` to be resolved before trying to restore a previous context upon closing the item previewer, as the `itemRunner.clear()` execution clears the whole context
- [TAO-10080](https://oat-sa.atlassian.net/browse/TAO-10080) fix: store an existing context when opening the item previewer
- [TAO-10080](https://oat-sa.atlassian.net/browse/TAO-10080) chore(version): bump a fix one

**Steps to reproduce**:

1. Add a hottext interaction to an item
2. Enable some hottext entries
3. Save the item
4. Preview the item
5. Close the preview
6. Go to the interaction response tab (at this point the interaction tries to find its elements in the context, but fails as it wasn't restored)
7. Go back to the question tab

ℹ️ The issue seems to be first introduced by #50.