### PR TITLE
[TAO-10170] Fix: Do not allow to preview empty items

### DIFF
--- a/controller/Previewer.php
+++ b/controller/Previewer.php
@@ -37,8 +37,8 @@ use oat\taoQtiTestPreviewer\models\PreviewLanguageService;
 use tao_actions_ServiceModule as ServiceModule;
 use tao_helpers_Http as HttpHelper;
 use tao_models_classes_FileNotFoundException as FileNotFoundException;
+use taoItems_models_classes_ItemsService;
 use taoQtiTest_helpers_TestRunnerUtils as TestRunnerUtils;
-use oat\taoItems\model\pack\ItemPack;
 use oat\taoItems\model\pack\Packer;
 
 /**
@@ -145,8 +145,12 @@ class Previewer extends ServiceModule
 
     /**
      * Provides the definition data and the state for a particular item
+     *
+     * @param taoItems_models_classes_ItemsService $itemsService
+     *
+     * @return void
      */
-    public function getItem()
+    public function getItem(taoItems_models_classes_ItemsService $itemsService)
     {
         $code = 200;
 
@@ -194,10 +198,14 @@ class Previewer extends ServiceModule
             } elseif ($itemUri) {
                 $item = $this->getResource($itemUri);
                 $lang = $this->getSession()->getDataLanguage();
+
+                if (!$itemsService->hasItemContent($item, $lang)) {
+                    return $this->returnJson($response, $code);
+                }
+
                 $packer = new Packer($item, $lang);
                 $packer->setServiceLocator($this->getServiceLocator());
 
-                /** @var ItemPack $itemPack */
                 $itemPack = $packer->pack();
                 $response['content'] = $itemPack->JsonSerialize();
                 $response['baseUrl'] = _url('asset', null, null, ['uri' => $itemUri, 'path' => '']);

--- a/manifest.php
+++ b/manifest.php
@@ -27,11 +27,11 @@ return [
     'label' => 'extension-tao-testqti-previewer',
     'description' => 'extension that provides QTI test previewer',
     'license'     => 'GPL-2.0',
-    'version' => '2.15.3',
+    'version' => '2.15.4',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'generis'      => '>=12.15.0',
-        'tao'          => '>=37.6.0',
+        'tao'          => '>=44.13.2',
         'taoTests'     => '>=12.0.0',
         'taoItems'     => '>=10.2.0',
         'taoQtiTest'   => '>=29.0.0',
@@ -58,10 +58,10 @@ return [
     ],
     'constants' => [
         # views directory
-        "DIR_VIEWS" => __DIR__ . DIRECTORY_SEPARATOR . 'views' . DIRECTORY_SEPARATOR,
+        'DIR_VIEWS' => __DIR__ . DIRECTORY_SEPARATOR . 'views' . DIRECTORY_SEPARATOR,
 
         #BASE URL (usually the domain root)
-        'BASE_URL' => ROOT_URL . 'taoQtiTestPreviewer/',
+        'BASE_URL'  => ROOT_URL . 'taoQtiTestPreviewer/',
     ],
     'extra' => [
         'structures' => __DIR__ . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . 'structures.xml',

--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return [
     'label' => 'extension-tao-testqti-previewer',
     'description' => 'extension that provides QTI test previewer',
     'license'     => 'GPL-2.0',
-    'version' => '2.15.4',
+    'version' => '2.16.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'generis'      => '>=12.15.0',


### PR DESCRIPTION
depends on: oat-sa/tao-core#2614

Ticket: TAO-10170

Fixed \taoItems_models_classes_ItemsService::hasItemContent

Now it checks if qti.xml of an item really exists. not only item properties. It allows disabling Preview button if there is nothing to preview

another part of the fix is here oat-sa/extension-tao-item#416