### PR TITLE
Fix [BSA 199] - Split onPartChange and onTestEnd in individual functions for show differents messages

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return [
     'label' => 'extension-tao-testqti-previewer',
     'description' => 'extension that provides QTI test previewer',
     'license'     => 'GPL-2.0',
-    'version' => '2.15.1',
+    'version' => '2.15.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'generis'      => '>=12.15.0',


### PR DESCRIPTION
**Related to this PR**

https://github.com/oat-sa/tao-test-runner-qti-fe/pull/285

**Related to**

https://oat-sa.atlassian.net/browse/BSA-199

**Context**

`BOSA` has applied certain Navigation warnings in the test settings. The existing pop up messages are not meeting their needs as they confuse the candidate. As such, they have requested to apply their specific pop up messages in Dutch and French language respectively.

**User story description**

As a test author, I want the candidate to view comprehensive pop up warnings when navigating from one Test part to another or from one test section to another. By doing so, the candidate will understand clearly was expected of them in the test.