### PR TITLE
Fix/BSA-202/Check the base64 encoded image

### DIFF
--- a/controller/Previewer.php
+++ b/controller/Previewer.php
@@ -20,6 +20,8 @@
 
 namespace oat\taoQtiTestPreviewer\controller;
 
+use common_exception_Error;
+use oat\tao\helpers\Base64;
 use common_Exception as CommonException;
 use common_exception_BadRequest as BadRequestException;
 use common_exception_MissingParameter as MissingParameterException;
@@ -224,10 +226,10 @@ class Previewer extends ServiceModule
 
     /**
      * Gets access to an asset
-     * @throws \common_exception_Error
-     * @throws FileNotFoundException
+     *
      * @throws CommonException
-     * @throws Exception
+     * @throws FileNotFoundException
+     * @throws common_exception_Error
      */
     public function asset()
     {
@@ -240,11 +242,15 @@ class Previewer extends ServiceModule
         $resolver = new ItemMediaResolver($item, $lang);
 
         $asset = $resolver->resolve($path);
-        if ($asset->getMediaSource() instanceof HttpSource) {
+        $mediaSource = $asset->getMediaSource();
+        $mediaIdentifier = $asset->getMediaIdentifier();
+
+        if ($mediaSource instanceof HttpSource || Base64::isEncodedImage($mediaIdentifier)) {
             throw new CommonException('Only tao files available for rendering through item preview');
         }
-        $info = $asset->getMediaSource()->getFileInfo($asset->getMediaIdentifier());
-        $stream = $asset->getMediaSource()->getFileStream($asset->getMediaIdentifier());
+
+        $info = $mediaSource->getFileInfo($mediaIdentifier);
+        $stream = $mediaSource->getFileStream($mediaIdentifier);
         HttpHelper::returnStream($stream, $info['mime']);
     }
 

--- a/manifest.php
+++ b/manifest.php
@@ -27,11 +27,11 @@ return [
     'label' => 'extension-tao-testqti-previewer',
     'description' => 'extension that provides QTI test previewer',
     'license'     => 'GPL-2.0',
-    'version' => '2.16.0',
+    'version' => '2.17.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'generis'      => '>=12.15.0',
-        'tao'          => '>=44.13.2',
+        'tao'          => '>=45.2.0',
         'taoTests'     => '>=12.0.0',
         'taoItems'     => '>=10.2.0',
         'taoQtiTest'   => '>=29.0.0',


### PR DESCRIPTION
Relates to: [BSA-202](https://oat-sa.atlassian.net/browse/BSA-202)

**Changes:**
* Added check for the base64 encoded image.

**Require:**
* [#2621](https://github.com/oat-sa/tao-core/pull/2621)