### PR TITLE
Fix UNO-631 provide item categories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "oat-sa/oatbox-extension-installer": "~1.1||dev-master"
+    "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
+    "qtism/qtism": "~0"
   },
   "autoload": {
     "psr-4": {
@@ -35,4 +36,3 @@
     }
   }
 }
-

--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return [
     'label' => 'extension-tao-testqti-previewer',
     'description' => 'extension that provides QTI test previewer',
     'license'     => 'GPL-2.0',
-    'version' => '2.20.1',
+    'version' => '2.20.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'generis'      => '>=12.15.0',

--- a/models/test/mapper/TestPreviewMapper.php
+++ b/models/test/mapper/TestPreviewMapper.php
@@ -26,8 +26,8 @@ use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\service\ConfigurableService;
 use oat\taoQtiTestPreviewer\models\test\TestPreviewConfig;
 use oat\taoQtiTestPreviewer\models\test\TestPreviewMap;
+use qtism\data\AssessmentItemRef;
 use qtism\data\AssessmentTest;
-use qtism\data\IAssessmentItem;
 use qtism\data\NavigationMode;
 use qtism\runtime\tests\Route;
 use qtism\runtime\tests\RouteItem;
@@ -61,10 +61,7 @@ class TestPreviewMapper extends ConfigurableService implements TestPreviewMapper
 
         /** @var RouteItem $routeItem */
         foreach ($routeItems as $routeItem) {
-            $itemRefs = $this->getRouteItemAssessmentItemRefs($routeItem);
-
-            /** @var IAssessmentItem $itemRef */
-            foreach ($itemRefs as $itemRef) {
+            foreach ($this->getRouteItemAssessmentItemRefs($routeItem) as $itemRef) {
                 $occurrence = $routeItem->getOccurence();
 
                 $isItemInformational = true; //@TODO Implement this as a feature
@@ -186,6 +183,11 @@ class TestPreviewMapper extends ConfigurableService implements TestPreviewMapper
         $target['stats']['total']++;
     }
 
+    /**
+     * @param RouteItem $routeItem
+     *
+     * @return AssessmentItemRef[]
+     */
     private function getRouteItemAssessmentItemRefs(RouteItem $routeItem): array
     {
         return [

--- a/models/test/mapper/TestPreviewMapper.php
+++ b/models/test/mapper/TestPreviewMapper.php
@@ -46,9 +46,7 @@ class TestPreviewMapper extends ConfigurableService implements TestPreviewMapper
         $routeItems = $route->getAllRouteItems();
         $checkInformational = $config->get(TestPreviewConfig::CHECK_INFORMATIONAL);
         $forceInformationalTitles = $config->get(TestPreviewConfig::REVIEW_FORCE_INFORMATION_TITLE);
-        $displaySubsectionTitle = $config->get(TestPreviewConfig::REVIEW_DISPLAY_SUBSECTION_TITLE) === null
-            ? true
-            : $config->get(TestPreviewConfig::REVIEW_DISPLAY_SUBSECTION_TITLE);
+        $displaySubsectionTitle = $config->get(TestPreviewConfig::REVIEW_DISPLAY_SUBSECTION_TITLE) ?? true;
 
         $map['title'] = $test->getTitle();
         $map['identifier'] = $test->getIdentifier();

--- a/models/test/mapper/TestPreviewMapper.php
+++ b/models/test/mapper/TestPreviewMapper.php
@@ -80,7 +80,7 @@ class TestPreviewMapper extends ConfigurableService implements TestPreviewMapper
                 $sectionId = $section->getIdentifier();
                 $itemId = $itemRef->getIdentifier();
 
-                if ($lastSection != $sectionId) {
+                if ($lastSection !== $sectionId) {
                     $offsetSection = 0;
                     $lastSection = $sectionId;
                 }

--- a/models/test/mapper/TestPreviewMapper.php
+++ b/models/test/mapper/TestPreviewMapper.php
@@ -97,7 +97,7 @@ class TestPreviewMapper extends ConfigurableService implements TestPreviewMapper
                     'answered' => 0,
                     'flagged' => false,
                     'viewed' => false,
-                    'categories' => [],
+                    'categories' => $itemRef->getCategories()->getArrayCopy(),
                 ];
 
                 if ($checkInformational) {

--- a/test/unit/models/test/mapper/TestPreviewMapperTest.php
+++ b/test/unit/models/test/mapper/TestPreviewMapperTest.php
@@ -59,7 +59,7 @@ class TestPreviewMapperTest extends TestCase
 
     public function testMapEmptyTest(): void
     {
-        $this->assertEquals(
+        static::assertEquals(
             new TestPreviewMap(
                 [
                     'scope' => 'test',
@@ -85,7 +85,7 @@ class TestPreviewMapperTest extends TestCase
 
         $this->expectsItemResource('itemUri', 'testLabel');
 
-        $this->assertEquals(
+        static::assertEquals(
             new TestPreviewMap(
                 [
                     'scope' => 'test',

--- a/test/unit/models/test/mapper/TestPreviewMapperTest.php
+++ b/test/unit/models/test/mapper/TestPreviewMapperTest.php
@@ -29,6 +29,7 @@ use oat\taoQtiTestPreviewer\models\test\mapper\TestPreviewMapper;
 use oat\taoQtiTestPreviewer\models\test\TestPreviewConfig;
 use oat\taoQtiTestPreviewer\models\test\TestPreviewMap;
 use PHPUnit\Framework\MockObject\MockObject;
+use qtism\common\collections\StringCollection;
 use qtism\data\AssessmentItemRef;
 use qtism\data\AssessmentSection;
 use qtism\data\AssessmentTest;
@@ -78,9 +79,15 @@ class TestPreviewMapperTest extends TestCase
 
     public function testMapFullTest(): void
     {
-        $testPart = $this->expectsTestPart('partId');
-        $section = $this->expectSection('sectionId', 'sectionTitle');
-        $itemRef = $this->expectsItemRef('itemUri', 'itemId');
+        $itemId       = 'itemId';
+        $sectionTitle = 'sectionTitle';
+        $categories   = [
+            'x-tao-test',
+        ];
+
+        $testPart  = $this->expectsTestPart('partId');
+        $section   = $this->expectSection('sectionId',  $sectionTitle);
+        $itemRef   = $this->expectsItemRef('itemUri', $itemId, $categories);
         $routeItem = $this->expectRouteItem($itemRef, $testPart, $section);
 
         $this->expectsItemResource('itemUri', 'testLabel');
@@ -98,12 +105,12 @@ class TestPreviewMapperTest extends TestCase
                             'sections' => [
                                 'sectionId' => [
                                     'id' => 'sectionId',
-                                    'label' => 'sectionTitle',
+                                    'label' => $sectionTitle,
                                     'isCatAdaptive' => false,
                                     'position' => 0,
                                     'items' => [
                                         'itemId' => [
-                                            'id' => 'itemId',
+                                            'id' => $itemId,
                                             'uri' => 'itemUri',
                                             'label' => 'testLabel',
                                             'position' => 0,
@@ -112,7 +119,7 @@ class TestPreviewMapperTest extends TestCase
                                             'answered' => 0,
                                             'flagged' => false,
                                             'viewed' => false,
-                                            'categories' => [],
+                                            'categories' => $categories,
                                         ],
                                     ],
                                     'stats' => [
@@ -170,7 +177,7 @@ class TestPreviewMapperTest extends TestCase
         return $itemResource;
     }
 
-    private function expectsItemRef(string $itemUri, string $itemId): AssessmentItemRef
+    private function expectsItemRef(string $itemUri, string $itemId, array $categories): AssessmentItemRef
     {
         $itemRef = $this->createMock(AssessmentItemRef::class);
 
@@ -179,6 +186,11 @@ class TestPreviewMapperTest extends TestCase
 
         $itemRef->method('getIdentifier')
             ->willReturn($itemId);
+
+        $itemRef->method('getCategories')
+            ->willReturn(
+                new StringCollection($categories)
+            );
 
         return $itemRef;
     }


### PR DESCRIPTION
- [UNO-631](https://oat-sa.atlassian.net/browse/UNO-631) fix(dependency): explicitly require `qtism/qtism` as its classes are being used directly by the extension
- [UNO-631](https://oat-sa.atlassian.net/browse/UNO-631) chore: use a null-coalescing operator instead of the ternary one in `TestPreviewMapper::map()` in order to retrieve a `review.displaySubsectionTitle`
- [UNO-631](https://oat-sa.atlassian.net/browse/UNO-631) chore: inline `TestPreviewMapper::getRouteItemAssessmentItemRefs()` call and add a docblock to it, specifying return-array elements' type
- [UNO-631](https://oat-sa.atlassian.net/browse/UNO-631) fix(code style): use a strict comparison in `TestPreviewMapper::map()` when comparing section IDs
- [UNO-631](https://oat-sa.atlassian.net/browse/UNO-631) fix(code style): static references to static test case methods in `TestPreviewMapperTest`
- [UNO-631](https://oat-sa.atlassian.net/browse/UNO-631) feat: provide actual item categories as a result of `TestPreviewMapper::map()`
- [UNO-631](https://oat-sa.atlassian.net/browse/UNO-631) chore(version): bump a fix one

⚠️ The fix doesn't cause any impact on the current behavior of the test previewer. The provided `categories` will be taken into account by the client side in a scope of [NEX-1520](https://github.com/oat-sa/extension-tao-testqti-previewer/pull/97).

ℹ️ The actual fix is [here](https://github.com/oat-sa/extension-tao-testqti-previewer/pull/95/commits/dcb02558958b62656ec21037b3e6083b5f07cead), the rest is just a few minor code-style modifications.