### PR TITLE
Feature NEX-1520 read test preview configuration from server side

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return [
     'label' => 'extension-tao-testqti-previewer',
     'description' => 'extension that provides QTI test previewer',
     'license'     => 'GPL-2.0',
-    'version' => '2.20.2',
+    'version' => '2.21.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'generis'      => '>=12.15.0',

--- a/models/testConfiguration/mapper/TestPreviewerConfigurationMapper.php
+++ b/models/testConfiguration/mapper/TestPreviewerConfigurationMapper.php
@@ -32,9 +32,10 @@ class TestPreviewerConfigurationMapper extends ConfigurableService
 {
     /**
      * @param ProviderModule[] $providerModules
-     * @param PluginModule[] $plugins
-     * @param mixed[] $options
+     * @param PluginModule[]   $plugins
+     * @param mixed[]          $options
      *
+     * @return TestPreviewerConfig
      */
     public function map(array $providerModules, array $plugins, array $options): TestPreviewerConfig
     {

--- a/models/testConfiguration/mapper/TestPreviewerConfigurationMapper.php
+++ b/models/testConfiguration/mapper/TestPreviewerConfigurationMapper.php
@@ -56,10 +56,6 @@ class TestPreviewerConfigurationMapper extends ConfigurableService
             if ($provider->isActive()) {
                 $category = $provider->getCategory();
 
-                if (!isset($providers[$category])) {
-                    $providers[$category] = [];
-                }
-
                 $providers[$category][] = $provider;
             }
         }

--- a/views/js/previewer/adapter/test/qtiTest.js
+++ b/views/js/previewer/adapter/test/qtiTest.js
@@ -49,21 +49,6 @@ define([
      */
     const defaultPlugins = [
         {
-            module: 'taoQtiTest/runner/plugins/tools/itemThemeSwitcher/itemThemeSwitcher',
-            bundle: 'taoQtiTest/loader/testPlugins.min',
-            category: 'tools'
-        },
-        {
-            module: 'taoQtiTest/runner/plugins/navigation/previous',
-            bundle: 'taoQtiTest/loader/testPlugins.min',
-            category: 'navigation'
-        },
-        {
-            module: 'taoQtiTest/runner/plugins/navigation/next',
-            bundle: 'taoQtiTest/loader/testPlugins.min',
-            category: 'navigation'
-        },
-        {
             module: 'taoQtiTestPreviewer/previewer/plugins/content/cloneLogoInTestPreview',
             bundle: 'taoQtiTestPreviewer/loader/qtiPreviewer.min',
             category: 'content'
@@ -71,7 +56,7 @@ define([
     ];
 
     const transformConfiguration = config => {
-        const plugins = Array.isArray(config.plugins) ? config.plugins : [];
+        const plugins = Array.isArray(config.plugins) ? [...defaultPlugins, ...config.plugins] : defaultPlugins;
         const {view, readOnly, fullPage, hideActionBars} = config;
         const options = _.omit({view, readOnly, fullPage, hideActionBars}, _.isUndefined);
 
@@ -80,7 +65,7 @@ define([
         }).then(response => {
             const configuration = response.data;
 
-            configuration.providers.plugins = (configuration.providers.plugins || defaultPlugins).concat(plugins);
+            configuration.providers.plugins = [...configuration.providers.plugins, ...plugins];
             _.assign(configuration.options, options);
 
             return configuration;

--- a/views/js/previewer/adapter/test/qtiTest.js
+++ b/views/js/previewer/adapter/test/qtiTest.js
@@ -18,8 +18,15 @@
 /**
  * @author Hanna Dzmitryieva <hanna@taotesting.com>
  */
-define(['lodash', 'core/logger', 'taoQtiTestPreviewer/previewer/component/test/qtiTest', 'ui/feedback'], function (
+define([
+    'lodash',
+    'core/promiseQueue',
+    'core/logger',
+    'taoQtiTestPreviewer/previewer/component/test/qtiTest',
+    'ui/feedback'
+], function (
     _,
+    promiseQueue,
     loggerFactory,
     qtiTestPreviewerFactory,
     feedback
@@ -61,6 +68,10 @@ define(['lodash', 'core/logger', 'taoQtiTestPreviewer/previewer/component/test/q
     return {
         name: 'qtiTest',
 
+        install() {
+            this.queue = promiseQueue();
+        },
+
         /**
          * Builds and shows the test previewer
          *
@@ -80,6 +91,12 @@ define(['lodash', 'core/logger', 'taoQtiTestPreviewer/previewer/component/test/q
                 }
                 logger.error(err);
             });
-        }
+        },
+
+        destroy() {
+            this.queue = null;
+
+            return Promise.resolve();
+        },
     };
 });

--- a/views/js/previewer/component/test/qtiTest.js
+++ b/views/js/previewer/component/test/qtiTest.js
@@ -20,12 +20,13 @@
  */
 define([
     'context',
-    'jquery',
+    'lodash',
+    'layout/loading-bar',
     'taoTests/runner/runnerComponent',
     'tpl!taoQtiTestPreviewer/previewer/component/test/tpl/qtiTest',
     'css!taoQtiTestPreviewer/previewer/component/test/css/qtiTest',
     'css!taoQtiTestCss/new-test-runner'
-], function (context, $, runnerComponentFactory, runnerTpl) {
+], function (context, __, loadingBar, runnerComponentFactory, runnerTpl) {
     'use strict';
 
     /**
@@ -36,15 +37,15 @@ define([
      * @returns {runner}
      */
     return function qtiTestPreviewerFactory(container, config = {}) {
-        const testRunnerConfig = {
-            ...config,
-            ...{
+        const testRunnerConfig = __.defaults(
+            {
                 testDefinition: 'test-container',
                 serviceCallId: 'previewer',
                 proxyProvider: 'qtiTestPreviewerProxy',
                 loadFromBundle: !!context.bundle,
-            }
-        };
+            },
+            config
+        );
 
         testRunnerConfig.providers.proxy = [{
             id: 'qtiTestPreviewerProxy',
@@ -61,7 +62,11 @@ define([
                 this.setState('hideactionbars', hideActionBars);
             })
             .on('ready', function(runner) {
-                runner.on('destroy', () => this.destroy());
+                runner.on('destroy', () => {
+                    // stop loading bar - started in plugin loading
+                    loadingBar.stop();
+                    this.destroy();
+                });
             });
     };
 });

--- a/views/js/previewer/component/test/qtiTest.js
+++ b/views/js/previewer/component/test/qtiTest.js
@@ -36,7 +36,8 @@ define([
      * @param {Object[]} [config.plugins] - Additional plugins to load
      * @param {String} [config.fullPage] - Force the previewer to occupy the full window.
      * @param {String} [config.readOnly] - Do not allow to modify the previewed item.
-     * @returns {previewer}
+     *
+     * @returns {runner}
      */
     return function qtiTestPreviewerFactory(container, config = {}) {
         const testRunnerConfig = {

--- a/views/js/previewer/component/test/qtiTest.js
+++ b/views/js/previewer/component/test/qtiTest.js
@@ -32,51 +32,26 @@ define([
      * Builds a test runner to preview test
      * @param {jQuery|HTMLElement|String} container - The container in which renders the component
      * @param {Object} [config] - The testRunner options
-     * @param {String} [config.testUri] - The test URI
-     * @param {Object[]} [config.plugins] - Additional plugins to load
-     * @param {String} [config.fullPage] - Force the previewer to occupy the full window.
-     * @param {String} [config.readOnly] - Do not allow to modify the previewed item.
      *
      * @returns {runner}
      */
     return function qtiTestPreviewerFactory(container, config = {}) {
         const testRunnerConfig = {
-            testDefinition: 'test-container',
-            serviceCallId: 'previewer',
-            providers: {
-                runner: {
-                    id: 'qti',
-                    module: 'taoQtiTest/runner/provider/qti',
-                    bundle: 'taoQtiTest/loader/taoQtiTestRunner.min',
-                    category: 'runner'
-                },
-                proxy: {
-                    id: 'qtiTestPreviewerProxy',
-                    module: 'taoQtiTestPreviewer/previewer/proxy/test',
-                    bundle: 'taoQtiTestPreviewer/loader/qtiPreviewer.min',
-                    category: 'proxy'
-                },
-                communicator: {
-                    id: 'request',
-                    module: 'core/communicator/request',
-                    bundle: 'loader/vendor.min',
-                    category: 'communicator'
-                },
-                plugins: config.plugins || []
-            },
-            options: {
-                view: config.view,
-                readOnly: config.readOnly,
-                fullPage: config.fullPage,
-                plugins: config.plugins,
-                hideActionBars: config.hideActionBars,
-                testUri: config.testUri
-            },
-            proxyProvider: 'qtiTestPreviewerProxy'
+            ...config,
+            ...{
+                testDefinition: 'test-container',
+                serviceCallId: 'previewer',
+                proxyProvider: 'qtiTestPreviewerProxy',
+                loadFromBundle: !!context.bundle,
+            }
         };
 
-        //extra context config
-        testRunnerConfig.loadFromBundle = !!context.bundle;
+        testRunnerConfig.providers.proxy = [{
+            id: 'qtiTestPreviewerProxy',
+            module: 'taoQtiTestPreviewer/previewer/proxy/test',
+            bundle: 'taoQtiTestPreviewer/loader/qtiPreviewer.min',
+            category: 'proxy'
+        }];
 
         return runnerComponentFactory(container, testRunnerConfig, runnerTpl)
             .on('render', function() {

--- a/views/js/test/previewer/adapter/qtiTest/test.js
+++ b/views/js/test/previewer/adapter/qtiTest/test.js
@@ -23,10 +23,11 @@ define([
 
     'jquery',
     'taoQtiTestPreviewer/previewer/adapter/test/qtiTest',
+    'json!taoQtiTestPreviewer/test/samples/json/configuration.json',
     'json!taoQtiTestPreviewer/test/samples/json/initTestPreview.json',
     'json!taoQtiTestPreviewer/test/samples/json/itemData.json',
     'lib/jquery.mockjax/jquery.mockjax'
-], function($, previewerAdapter, initTestPreview, itemData) {
+], function($, previewerAdapter, configuration, initTestPreview, itemData) {
     'use strict';
 
     QUnit.module('API');
@@ -65,6 +66,11 @@ define([
             $.mockjax.clear();
 
             $.mockjax({
+                url: '*/configuration',
+                responseText: configuration
+            });
+
+            $.mockjax({
                 url: '*/init',
                 responseText: initTestPreview
             });
@@ -80,12 +86,13 @@ define([
         assert.expect(1);
 
         displayPreviewer(configReadOnly)
-            .before('ready', function(e, runner) {
-                runner.after('renderitem.runnerComponent', function() {
-                    assert.ok(true, 'The previewer has been rendered');
-                    ready();
-                });
-            });
+            .then(displayPreviewer =>
+                displayPreviewer.before('ready', function (e, runner) {
+                    runner.after('renderitem.runnerComponent', function () {
+                        assert.ok(true, 'The previewer has been rendered');
+                        ready();
+                    });
+                }));
 
         $('#show-interactive').on('click', function(e) {
             e.preventDefault();

--- a/views/js/test/previewer/component/qtiTest/test.js
+++ b/views/js/test/previewer/component/qtiTest/test.js
@@ -23,10 +23,11 @@ define([
     'jquery',
     'lodash',
     'taoQtiTestPreviewer/previewer/component/test/qtiTest',
+    'json!taoQtiTestPreviewer/test/samples/json/configuration.json',
     'json!taoQtiTestPreviewer/test/samples/json/initTestPreview.json',
     'json!taoQtiTestPreviewer/test/samples/json/itemData.json',
     'lib/jquery.mockjax/jquery.mockjax'
-], function($, _, qtiTestPreviewerFactory, initTestPreview, itemData) {
+], function($, _, qtiTestPreviewerFactory, configuration, initTestPreview, itemData) {
     'use strict';
 
     QUnit.module('API');
@@ -40,31 +41,11 @@ define([
         $.mockjax.clear();
     });
 
-    const plugins = [
-        {
-            module: 'taoQtiTest/runner/plugins/tools/itemThemeSwitcher/itemThemeSwitcher',
-            bundle: 'taoQtiTest/loader/testPlugins.min',
-            category: 'tools'
-        },
-        {
-            module: 'taoQtiTest/runner/plugins/navigation/previous',
-            bundle: 'taoQtiTest/loader/testPlugins.min',
-            category: 'navigation'
-        },
-        {
-            module: 'taoQtiTest/runner/plugins/navigation/next',
-            bundle: 'taoQtiTest/loader/testPlugins.min',
-            category: 'navigation'
-        }
-    ];
     QUnit.test('module', assert =>  {
         const ready = assert.async();
-        const config = {
-            plugins
-        };
 
-        const previewer1 = qtiTestPreviewerFactory('#fixture-api', config);
-        const previewer2 = qtiTestPreviewerFactory('#fixture-api', config);
+        const previewer1 = qtiTestPreviewerFactory('#fixture-api', configuration.data);
+        const previewer2 = qtiTestPreviewerFactory('#fixture-api', configuration.data);
 
         assert.expect(4);
         $.mockjax({
@@ -104,15 +85,12 @@ define([
     }]).test('render test ', (data, assert) =>  {
         const ready = assert.async();
         const $container = $('#fixture-render');
-        const config = {
-            plugins
-        };
 
         assert.expect(1);
 
         $.mockjax(data.mock);
 
-        qtiTestPreviewerFactory($container, config)
+        qtiTestPreviewerFactory($container, configuration.data)
             .on('error', function(err) {
                 assert.ok(false, 'An error has occurred');
                 assert.pushResult({
@@ -131,16 +109,17 @@ define([
 
     QUnit.test('config', assert => {
         const ready = assert.async();
-        const config = {
+        const config = configuration.data;
+
+        _.assign(config.options, {
             view: 'scorer',
             readOnly: true,
             fullPage: true,
             hideActionBars: true,
-            plugins
-        };
+        });
 
         const previewerWithOptions = qtiTestPreviewerFactory('#fixture-api', config);
-        const previewerWithoutOptions = qtiTestPreviewerFactory('#fixture-api', { plugins });
+        const previewerWithoutOptions = qtiTestPreviewerFactory('#fixture-api', configuration.data);
 
         assert.expect(2);
         $.mockjax({
@@ -164,12 +143,12 @@ define([
         }).then(([runnerWithOptions, runnerWithoutOptions]) => {
             assert.deepEqual(
                 runnerWithOptions.getConfig().options,
-                { view: 'scorer', readOnly: true, fullPage: true, plugins: plugins, hideActionBars: true, testUri: undefined },
+                config.options,
                 'The previewer factory set options using config'
             );
             assert.deepEqual(
                 runnerWithoutOptions.getConfig().options,
-                { view: undefined,readOnly: undefined, fullPage: undefined, plugins: plugins, hideActionBars: undefined, testUri: undefined },
+                configuration.data.options,
                 'The previewer factory leave options undefined if config empty'
             );
 
@@ -180,7 +159,6 @@ define([
     QUnit.test('destroy', assert =>  {
         const ready = assert.async();
         const $container = $('#fixture-destroy');
-        const config = { plugins };
 
         assert.expect(2);
 
@@ -194,7 +172,7 @@ define([
             responseText: itemData
         });
 
-        qtiTestPreviewerFactory($container, config)
+        qtiTestPreviewerFactory($container, configuration.data)
             .on('error', function(err) {
                 assert.ok(false, 'An error has occurred');
                 assert.pushResult({
@@ -218,7 +196,6 @@ define([
     QUnit.test('Visual test', function (assert) {
         const ready = assert.async();
         const $container = $('#visual-test');
-        const config = { plugins };
 
         assert.expect(1);
 
@@ -232,7 +209,7 @@ define([
             responseText: itemData
         });
 
-        qtiTestPreviewerFactory($container, config)
+        qtiTestPreviewerFactory($container, configuration.data)
             .on('error', function(err) {
                 assert.ok(false, 'An error has occurred');
                 assert.pushResult({

--- a/views/js/test/samples/json/configuration.json
+++ b/views/js/test/samples/json/configuration.json
@@ -1,0 +1,664 @@
+  {
+    "success": true,
+    "data": {
+      "providers": {
+        "runner": [
+          {
+            "id": "qti",
+            "module": "taoQtiTest\/runner\/provider\/qti",
+            "bundle": "taoQtiTest\/loader\/taoQtiTestRunner.min",
+            "position": null,
+            "name": "QTI runner",
+            "description": "QTI implementation of the test runner",
+            "category": "runner",
+            "active": true,
+            "tags": [
+              "core",
+              "qti",
+              "runner"
+            ]
+          }
+        ],
+        "communicator": [
+          {
+            "id": "request",
+            "module": "core\/communicator\/request",
+            "bundle": null,
+            "position": null,
+            "name": "request communicator",
+            "description": "",
+            "category": "communicator",
+            "active": true,
+            "tags": []
+          },
+          {
+            "id": "poll",
+            "module": "core\/communicator\/poll",
+            "bundle": null,
+            "position": null,
+            "name": "poll communicator",
+            "description": "",
+            "category": "communicator",
+            "active": true,
+            "tags": []
+          }
+        ],
+        "proxy": [
+          {
+            "id": "qtiServiceProxy",
+            "module": "taoQtiTest\/runner\/proxy\/qtiServiceProxy",
+            "bundle": "taoQtiTest\/loader\/taoQtiTestRunner.min",
+            "position": null,
+            "name": "",
+            "description": "",
+            "category": "proxy",
+            "active": true,
+            "tags": []
+          }
+        ],
+        "plugins": [
+          {
+            "id": "rubricBlock",
+            "module": "taoQtiTest\/runner\/plugins\/content\/rubricBlock\/rubricBlock",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Rubric Block",
+            "description": "Display test rubric blocks",
+            "category": "content",
+            "active": true,
+            "tags": [
+              "core",
+              "qti"
+            ]
+          },
+          {
+            "id": "overlay",
+            "module": "taoQtiTest\/runner\/plugins\/content\/overlay\/overlay",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Overlay",
+            "description": "Add an overlay over items when disabled",
+            "category": "content",
+            "active": true,
+            "tags": [
+              "core",
+              "technical",
+              "required"
+            ]
+          },
+          {
+            "id": "dialog",
+            "module": "taoQtiTest\/runner\/plugins\/content\/dialog\/dialog",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Dialog",
+            "description": "Display popups that require user interactions",
+            "category": "content",
+            "active": true,
+            "tags": [
+              "core",
+              "technical",
+              "required"
+            ]
+          },
+          {
+            "id": "feedback",
+            "module": "taoQtiTest\/runner\/plugins\/content\/feedback\/feedback",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Feedback",
+            "description": "Display notifications into feedback popups",
+            "category": "content",
+            "active": true,
+            "tags": [
+              "core",
+              "technical",
+              "required"
+            ]
+          },
+          {
+            "id": "exitMessages",
+            "module": "taoQtiTest\/runner\/plugins\/content\/dialog\/exitMessages",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Exit Messages",
+            "description": "Display messages when a test taker leaves the test",
+            "category": "content",
+            "active": true,
+            "tags": [
+              "core"
+            ]
+          },
+          {
+            "id": "loading",
+            "module": "taoQtiTest\/runner\/plugins\/content\/loading\/loading",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Loading bar",
+            "description": "Show a loading bar when the test is loading",
+            "category": "content",
+            "active": true,
+            "tags": [
+              "core"
+            ]
+          },
+          {
+            "id": "title",
+            "module": "taoQtiTest\/runner\/plugins\/controls\/title\/title",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Title indicator",
+            "description": "Display the title of current test element",
+            "category": "controls",
+            "active": true,
+            "tags": [
+              "core"
+            ]
+          },
+          {
+            "id": "modalFeedback",
+            "module": "taoQtiTest\/runner\/plugins\/content\/modalFeedback\/modalFeedback",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "QTI modal feedbacks",
+            "description": "Display Qti modalFeedback element",
+            "category": "content",
+            "active": true,
+            "tags": [
+              "core",
+              "qti",
+              "required"
+            ]
+          },
+          {
+            "id": "keyNavigation",
+            "module": "taoQtiTest\/runner\/plugins\/content\/accessibility\/keyNavigation\/plugin",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Keyboard Navigation",
+            "description": "Provide a way to navigate within the test runner with the keyboard",
+            "category": "content",
+            "active": true,
+            "tags": [
+              "core",
+              "qti"
+            ]
+          },
+          {
+            "id": "collapser",
+            "module": "taoQtiTest\/runner\/plugins\/content\/responsiveness\/collapser",
+            "bundle": null,
+            "position": null,
+            "name": "Collapser",
+            "description": "Reduce the size of the tools when the available space is not enough",
+            "category": "content",
+            "active": true,
+            "tags": [
+              "core"
+            ]
+          },
+          {
+            "id": "focusOnFirstField",
+            "module": "taoQtiTest\/runner\/plugins\/content\/accessibility\/focusOnFirstField",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Focus on first form field",
+            "description": "Sets focus on first form field",
+            "category": "content",
+            "active": true,
+            "tags": []
+          },
+          {
+            "id": "timer",
+            "module": "taoQtiTest\/runner\/plugins\/controls\/timer\/plugin",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Timer indicator",
+            "description": "Add countdown when remaining time",
+            "category": "controls",
+            "active": true,
+            "tags": [
+              "core",
+              "qti"
+            ]
+          },
+          {
+            "id": "progressbar",
+            "module": "taoQtiTest\/runner\/plugins\/controls\/progressbar\/progressbar",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Progress indicator",
+            "description": "Display the current progression within the test",
+            "category": "controls",
+            "active": true,
+            "tags": [
+              "core"
+            ]
+          },
+          {
+            "id": "duration",
+            "module": "taoQtiTest\/runner\/plugins\/controls\/duration\/duration",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Duration record",
+            "description": "Record accurately time spent by the test taker",
+            "category": "controls",
+            "active": true,
+            "tags": [
+              "core",
+              "technical",
+              "required"
+            ]
+          },
+          {
+            "id": "connectivity",
+            "module": "taoQtiTest\/runner\/plugins\/controls\/connectivity\/connectivity",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Connectivity check",
+            "description": "Pause the test when the network loose the connection",
+            "category": "controls",
+            "active": true,
+            "tags": [
+              "core",
+              "technical"
+            ]
+          },
+          {
+            "id": "testState",
+            "module": "taoQtiTest\/runner\/plugins\/controls\/testState\/testState",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Test state",
+            "description": "Manage test state",
+            "category": "controls",
+            "active": true,
+            "tags": [
+              "core",
+              "technical",
+              "required"
+            ]
+          },
+          {
+            "id": "review",
+            "module": "taoQtiTest\/runner\/plugins\/navigation\/review\/review",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Navigation and review panel",
+            "description": "Enable a panel to handle navigation and item reviews",
+            "category": "navigation",
+            "active": true,
+            "tags": [
+              "core"
+            ]
+          },
+          {
+            "id": "previous",
+            "module": "taoQtiTest\/runner\/plugins\/navigation\/previous",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Previous button",
+            "description": "Enable to move backward",
+            "category": "navigation",
+            "active": true,
+            "tags": [
+              "core",
+              "qti",
+              "required"
+            ]
+          },
+          {
+            "id": "next",
+            "module": "taoQtiTest\/runner\/plugins\/navigation\/next",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Next button",
+            "description": "Enable to move forward",
+            "category": "navigation",
+            "active": true,
+            "tags": [
+              "core",
+              "qti",
+              "required"
+            ]
+          },
+          {
+            "id": "nextSection",
+            "module": "taoQtiTest\/runner\/plugins\/navigation\/nextSection",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Next section button",
+            "description": "Enable to move to the next available section",
+            "category": "navigation",
+            "active": true,
+            "tags": [
+              "core",
+              "qti"
+            ]
+          },
+          {
+            "id": "skip",
+            "module": "taoQtiTest\/runner\/plugins\/navigation\/skip",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Skip button",
+            "description": "Skip the current item",
+            "category": "navigation",
+            "active": true,
+            "tags": [
+              "core",
+              "qti"
+            ]
+          },
+          {
+            "id": "allowSkipping",
+            "module": "taoQtiTest\/runner\/plugins\/navigation\/allowSkipping",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Allow Skipping",
+            "description": "Prevent submission of default\/null responses",
+            "category": "navigation",
+            "active": true,
+            "tags": [
+              "core",
+              "qti"
+            ]
+          },
+          {
+            "id": "validateResponses",
+            "module": "taoQtiTest\/runner\/plugins\/navigation\/validateResponses",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Validate Responses",
+            "description": "Prevent submission of invalid responses",
+            "category": "navigation",
+            "active": true,
+            "tags": [
+              "core",
+              "qti"
+            ]
+          },
+          {
+            "id": "comment",
+            "module": "taoQtiTest\/runner\/plugins\/tools\/comment\/comment",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Comment tool",
+            "description": "Allow test taker to comment an item",
+            "category": "tools",
+            "active": true,
+            "tags": [
+              "core",
+              "qti"
+            ]
+          },
+          {
+            "id": "calculator",
+            "module": "taoQtiTest\/runner\/plugins\/tools\/calculator",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Caculator tool",
+            "description": "Gives the student access to a basic calculator",
+            "category": "tools",
+            "active": true,
+            "tags": [
+              "core"
+            ]
+          },
+          {
+            "id": "zoom",
+            "module": "taoQtiTest\/runner\/plugins\/tools\/zoom",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Zoom",
+            "description": "Zoom in and out the item content",
+            "category": "tools",
+            "active": true,
+            "tags": [
+              "core"
+            ]
+          },
+          {
+            "id": "highlighter",
+            "module": "taoQtiTest\/runner\/plugins\/tools\/highlighter\/plugin",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Text Highlighter",
+            "description": "Allows the test taker to highlight text",
+            "category": "tools",
+            "active": true,
+            "tags": []
+          },
+          {
+            "id": "magnifier",
+            "module": "taoQtiTest\/runner\/plugins\/tools\/magnifier\/magnifier",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Magnifier",
+            "description": "Gives student access to a magnification tool",
+            "category": "tools",
+            "active": true,
+            "tags": []
+          },
+          {
+            "id": "lineReader",
+            "module": "taoQtiTest\/runner\/plugins\/tools\/lineReader\/plugin",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Line Reader",
+            "description": "Display a customisable mask with a customisable hole in it!",
+            "category": "tools",
+            "active": true,
+            "tags": []
+          },
+          {
+            "id": "answerMasking",
+            "module": "taoQtiTest\/runner\/plugins\/tools\/answerMasking\/plugin",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Answer Masking",
+            "description": "Hide all answers of a choice interaction and allow revealing them",
+            "category": "tools",
+            "active": true,
+            "tags": []
+          },
+          {
+            "id": "eliminator",
+            "module": "taoQtiTest\/runner\/plugins\/tools\/answerElimination\/eliminator",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Eliminate choices",
+            "description": "Allows student to eliminate choices",
+            "category": "tools",
+            "active": true,
+            "tags": []
+          },
+          {
+            "id": "area-masking",
+            "module": "taoQtiTest\/runner\/plugins\/tools\/areaMasking\/areaMasking",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "Area Masking",
+            "description": "Mask areas of the item",
+            "category": "tools",
+            "active": true,
+            "tags": []
+          },
+          {
+            "id": "apiptts",
+            "module": "taoQtiTest\/runner\/plugins\/tools\/apipTextToSpeech\/plugin",
+            "bundle": "taoQtiTest\/loader\/testPlugins.min",
+            "position": null,
+            "name": "APIP Text To Speech",
+            "description": "Allow Test-taker to playback media files associated according to APIP protocol to item content.",
+            "category": "tools",
+            "active": true,
+            "tags": []
+          }
+        ]
+      },
+      "options": {
+        "timerWarning": {
+          "assessmentItemRef": null,
+          "assessmentSection": null,
+          "testPart": null,
+          "assessmentTest": null
+        },
+        "timerWarningForScreenreader": null,
+        "catEngineWarning": null,
+        "progressIndicator": {
+          "type": "percentage",
+          "renderer": "percentage",
+          "scope": "test",
+          "forced": false,
+          "showLabel": true,
+          "showTotal": true,
+          "categories": []
+        },
+        "review": {
+          "enabled": true,
+          "scope": "test",
+          "useTitle": true,
+          "forceTitle": false,
+          "forceInformationalTitle": false,
+          "showLegend": true,
+          "defaultOpen": true,
+          "itemTitle": "Item %d",
+          "informationalItemTitle": "Instructions",
+          "preventsUnseen": true,
+          "canCollapse": false,
+          "displaySubsectionTitle": true,
+          "allowSkipahead": false
+        },
+        "exitButton": false,
+        "nextSection": false,
+        "plugins": {
+          "answer-masking": {
+            "restoreStateOnToggle": true,
+            "restoreStateOnMove": true
+          },
+          "validateResponses": {
+            "validateOnPreviousMove": true
+          },
+          "overlay": {
+            "full": false
+          },
+          "collapser": {
+            "collapseTools": true,
+            "collapseNavigation": false,
+            "collapseInOrder": false,
+            "hover": false,
+            "collapseOrder": []
+          },
+          "magnifier": {
+            "zoomMin": 2,
+            "zoomMax": 8,
+            "zoomStep": 0.5
+          },
+          "calculator": {
+            "template": "",
+            "degree": true
+          },
+          "dialog": {
+            "alert": {
+              "focus": "navigable-modal-body"
+            },
+            "confirm": {
+              "focus": "navigable-modal-body"
+            }
+          },
+          "keyNavigation": {
+            "contentNavigatorType": "default"
+          },
+          "answerCache": {
+            "allAttempts": false
+          },
+          "sessionHeartbeat": {
+            "interval": "900",
+            "action": "up"
+          }
+        },
+        "security": {
+          "csrfToken": true
+        },
+        "timer": {
+          "target": "server",
+          "resetAfterResume": false,
+          "keepUpToTimeout": false,
+          "restoreTimerFromClient": false
+        },
+        "enableAllowSkipping": true,
+        "enableValidateResponses": true,
+        "checkInformational": true,
+        "enableUnansweredItemsWarning": true,
+        "allowShortcuts": true,
+        "shortcuts": {
+          "calculator": {
+            "toggle": "C"
+          },
+          "zoom": {
+            "in": "I",
+            "out": "O"
+          },
+          "comment": {
+            "toggle": "A"
+          },
+          "itemThemeSwitcher": {
+            "toggle": "T"
+          },
+          "review": {
+            "toggle": "R",
+            "flag": "M"
+          },
+          "keyNavigation": {
+            "previous": "Shift+Tab",
+            "next": "Tab"
+          },
+          "next": {
+            "trigger": "J",
+            "triggerAccessibility": "Alt+Shift+N"
+          },
+          "previous": {
+            "trigger": "K",
+            "triggerAccessibility": "Alt+Shift+P"
+          },
+          "dialog": [],
+          "magnifier": {
+            "toggle": "L",
+            "in": "Shift+I",
+            "out": "Shift+O",
+            "close": "esc"
+          },
+          "highlighter": {
+            "toggle": "Shift+U"
+          },
+          "area-masking": {
+            "toggle": "Y"
+          },
+          "line-reader": {
+            "toggle": "G"
+          },
+          "answer-masking": {
+            "toggle": "D"
+          },
+          "apiptts": {
+            "enterTogglePlayback": "Enter",
+            "togglePlayback": "P",
+            "spaceTogglePlayback": "Space"
+          },
+          "jumplinks": {
+            "goToQuestion": "Alt+Shift+Q",
+            "goToTop": "Alt+Shift+T"
+          }
+        },
+        "itemCaching": {
+          "enabled": false,
+          "amount": 3
+        },
+        "guidedNavigation": false,
+        "toolStateServerStorage": [],
+        "forceEnableLinearNextItemWarning": false,
+        "enableLinearNextItemWarningCheckbox": true
+      }
+    }
+  }


### PR DESCRIPTION
- [NEX-1520](https://oat-sa.atlassian.net/browse/NEX-1520) fix: return type of `qtiTest.qtiTestPreviewerFactory()`
- [NEX-1520](https://oat-sa.atlassian.net/browse/NEX-1520) feat: initialize a `promiseQueue` in `previewer/adapter/qtiTest` to ensure requests order when a `TestPreviewer/configuration` request will be added
- [NEX-1520](https://oat-sa.atlassian.net/browse/NEX-1520) fix: add a missing `@return` annotation to `TestPreviewerConfigurationMapper::map()`'s docblock
- [NEX-1520](https://oat-sa.atlassian.net/browse/NEX-1520) chore: remove a redundant conditional statement from `TestPreviewerConfigurationMapper::getActiveProviders()`
- [NEX-1520](https://oat-sa.atlassian.net/browse/NEX-1520) feat: use server-side test preview configuration, acquired from `TestPreviewer/configuration` when initializing `qtiTestPreviewerFactory`
- [NEX-1520](https://oat-sa.atlassian.net/browse/NEX-1520) chore(version): bump a minor one