### PR TITLE
Fix/NEX-2151/support media from Assets folder

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return [
     'label' => 'extension-tao-testqti-previewer',
     'description' => 'extension that provides QTI test previewer',
     'license'     => 'GPL-2.0',
-    'version' => '2.22.1',
+    'version' => '2.22.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'generis'      => '>=12.15.0',

--- a/views/js/previewer/adapter/test/qtiTest.js
+++ b/views/js/previewer/adapter/test/qtiTest.js
@@ -93,9 +93,9 @@ define([
          * @returns {Object}
          */
         init(testUri, config = {}) {
-            return transformConfiguration(config).then(config => {
-                config.options.testUri = testUri;
-                return qtiTestPreviewerFactory(window.document.body, config).on('error', function (err) {
+            return transformConfiguration(config).then(testPreviewConfig => {
+                testPreviewConfig.options.testUri = testUri;
+                return qtiTestPreviewerFactory(window.document.body, testPreviewConfig).on('error', function (err) {
                     if (!_.isUndefined(err.message)) {
                         feedback().error(err.message);
                     }

--- a/views/js/previewer/component/test/qtiTest.js
+++ b/views/js/previewer/component/test/qtiTest.js
@@ -23,10 +23,12 @@ define([
     'lodash',
     'layout/loading-bar',
     'taoTests/runner/runnerComponent',
+    'taoQtiTest/runner/config/assetManager',
+    'taoItems/assets/strategies',
     'tpl!taoQtiTestPreviewer/previewer/component/test/tpl/qtiTest',
     'css!taoQtiTestPreviewer/previewer/component/test/css/qtiTest',
     'css!taoQtiTestCss/new-test-runner'
-], function (context, __, loadingBar, runnerComponentFactory, runnerTpl) {
+], function (context, __, loadingBar, runnerComponentFactory, assetManagerFactory, assetStrategies, runnerTpl) {
     'use strict';
 
     /**
@@ -53,6 +55,10 @@ define([
             bundle: 'taoQtiTestPreviewer/loader/qtiPreviewer.min',
             category: 'proxy'
         }];
+
+        //the asset manager should support taomedia strategy
+        const assetManager = assetManagerFactory(testRunnerConfig.serviceCallId);
+        assetManager.prependStrategy(assetStrategies.taomedia);
 
         return runnerComponentFactory(container, testRunnerConfig, runnerTpl)
             .on('render', function() {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/NEX-2151

Add `taomedia` strategy in assetManager for the test preview.

How to test:

- create an item with image/sound/video from Assets folder
- create an test with the item
- open Preview for the test