### PR TITLE
fix/NEX-2152/Test Preview: save itemState in itemStore before move

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return [
     'label' => 'extension-tao-testqti-previewer',
     'description' => 'extension that provides QTI test previewer',
     'license'     => 'GPL-2.0',
-    'version' => '2.22.2',
+    'version' => '2.22.3',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'generis'      => '>=12.15.0',

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return [
     'label' => 'extension-tao-testqti-previewer',
     'description' => 'extension that provides QTI test previewer',
     'license'     => 'GPL-2.0',
-    'version' => '2.22.1',
+    'version' => '2.22.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'generis'      => '>=12.15.0',

--- a/views/js/test/previewer/proxy/test/test.js
+++ b/views/js/test/previewer/proxy/test/test.js
@@ -386,7 +386,8 @@ define([
                 itemPosition: 1,
                 sectionId: 'assessmentSection-1',
                 state: 0,
-                testPartId: 'testPart-1'
+                testPartId: 'testPart-1',
+                itemSessionState: 0
             },
         }, {
             title: 'move jump',
@@ -402,7 +403,8 @@ define([
                 itemPosition: 1,
                 sectionId: 'assessmentSection-1',
                 state: 0,
-                testPartId: 'testPart-1'
+                testPartId: 'testPart-1',
+                itemSessionState: 0
             },
         }, {
             title: 'skip next',
@@ -417,7 +419,8 @@ define([
                 itemPosition: 1,
                 sectionId: 'assessmentSection-1',
                 state: 0,
-                testPartId: 'testPart-1'
+                testPartId: 'testPart-1',
+                itemSessionState: 0
             },
         }])
         .test('testProxy.callItemAction ', function(caseData, assert) {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/NEX-2152

Save itemState in itemStore before move to next item.

How to test:
- open Test Preview
- set answers on the item
- go to the next item
- return to answered item
- check that response are applied