### PR TITLE
Fix/NEX-2149/Fix testMap properties

### DIFF
--- a/controller/TestPreviewer.php
+++ b/controller/TestPreviewer.php
@@ -45,10 +45,11 @@ class TestPreviewer extends tao_actions_ServiceModule
                 throw  new InvalidArgumentException('Required `testUri` param is missing ');
             }
 
-            $response = $this->getTestPreviewerService()
-                ->createPreview(new TestPreviewRequest($requestParams['testUri'], new TestPreviewConfig([
-                    TestPreviewConfig::CHECK_INFORMATIONAL => true,
-                ])));
+            $testPreviewRequest = new TestPreviewRequest(
+                $requestParams['testUri'],
+                new TestPreviewConfig([TestPreviewConfig::CHECK_INFORMATIONAL => true])
+            );
+            $response = $this->getTestPreviewerService()->createPreview($testPreviewRequest);
 
             $this->setNoCacheHeaders();
 

--- a/controller/TestPreviewer.php
+++ b/controller/TestPreviewer.php
@@ -25,6 +25,7 @@ namespace oat\taoQtiTestPreviewer\controller;
 use common_exception_UserReadableException;
 use InvalidArgumentException;
 use oat\tao\model\http\HttpJsonResponseTrait;
+use oat\taoQtiTestPreviewer\models\test\TestPreviewConfig;
 use oat\taoQtiTestPreviewer\models\test\service\TestPreviewer as TestPreviewerService;
 use oat\taoQtiTestPreviewer\models\test\TestPreviewRequest;
 use oat\taoQtiTestPreviewer\models\testConfiguration\service\TestPreviewerConfigurationService;
@@ -45,7 +46,9 @@ class TestPreviewer extends tao_actions_ServiceModule
             }
 
             $response = $this->getTestPreviewerService()
-                ->createPreview(new TestPreviewRequest($requestParams['testUri']));
+                ->createPreview(new TestPreviewRequest($requestParams['testUri'], new TestPreviewConfig([
+                    TestPreviewConfig::CHECK_INFORMATIONAL => true,
+                ])));
 
             $this->setNoCacheHeaders();
 

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return [
     'label' => 'extension-tao-testqti-previewer',
     'description' => 'extension that provides QTI test previewer',
     'license'     => 'GPL-2.0',
-    'version' => '2.22.3',
+    'version' => '2.22.4',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'generis'      => '>=12.15.0',

--- a/models/test/mapper/TestPreviewMapper.php
+++ b/models/test/mapper/TestPreviewMapper.php
@@ -49,7 +49,7 @@ class TestPreviewMapper extends ConfigurableService implements TestPreviewMapper
         ];
 
         $routeItems = $route->getAllRouteItems();
-        $checkInformational = $config->get(TestPreviewConfig::CHECK_INFORMATIONAL);
+        $checkForInformationalItem = $config->get(TestPreviewConfig::CHECK_INFORMATIONAL);
         $forceInformationalTitles = $config->get(TestPreviewConfig::REVIEW_FORCE_INFORMATION_TITLE);
         $displaySubsectionTitle = $config->get(TestPreviewConfig::REVIEW_DISPLAY_SUBSECTION_TITLE) ?? true;
 
@@ -68,8 +68,6 @@ class TestPreviewMapper extends ConfigurableService implements TestPreviewMapper
         foreach ($routeItems as $routeItem) {
             foreach ($this->getRouteItemAssessmentItemRefs($routeItem) as $itemRef) {
                 $occurrence = $routeItem->getOccurence();
-
-                $isItemInformational = true; //@TODO Implement this as a feature
 
                 $testPart = $routeItem->getTestPart();
                 $partId = $testPart->getIdentifier();
@@ -105,12 +103,10 @@ class TestPreviewMapper extends ConfigurableService implements TestPreviewMapper
                     'categories' => $itemRef->getCategories()->getArrayCopy(),
                 ];
 
-                if ($checkInformational) {
-                    $isItemInformational = in_array(
-                        'x-tao-itemusage-informational',
-                        $itemInfos['categories'],
-                        true
-                    );
+                $isItemInformational = true;
+
+                if ($checkForInformationalItem) {
+                    $isItemInformational = $this->isItemInformational($itemInfos['categories']);
                     $itemInfos['informational'] = $isItemInformational;
                 }
 
@@ -230,5 +226,15 @@ class TestPreviewMapper extends ConfigurableService implements TestPreviewMapper
         }
 
         return $this->service;
+    }
+
+    /**
+     * @param $categories
+     *
+     * @return bool
+     */
+    private function isItemInformational($categories): bool
+    {
+        return in_array('x-tao-itemusage-informational', $categories, true);
     }
 }

--- a/test/unit/models/test/mapper/TestPreviewMapperTest.php
+++ b/test/unit/models/test/mapper/TestPreviewMapperTest.php
@@ -25,6 +25,7 @@ namespace oat\taoQtiTestPreviewer\test\unit\models\test\factory;
 use core_kernel_classes_Resource;
 use oat\generis\model\data\Ontology;
 use oat\generis\test\TestCase;
+use oat\taoQtiItem\model\qti\Service;
 use oat\taoQtiTestPreviewer\models\test\mapper\TestPreviewMapper;
 use oat\taoQtiTestPreviewer\models\test\TestPreviewConfig;
 use oat\taoQtiTestPreviewer\models\test\TestPreviewMap;
@@ -52,7 +53,8 @@ class TestPreviewMapperTest extends TestCase
         $this->subject->setServiceLocator(
             $this->getServiceLocatorMock(
                 [
-                    Ontology::SERVICE_ID => $this->ontology
+                    Ontology::SERVICE_ID => $this->ontology,
+                    Service::class => $this->createMock(Service::class),
                 ]
             )
         );


### PR DESCRIPTION
Relates to: [NEX-2149](https://oat-sa.atlassian.net/browse/NEX-2149)

**Changes:**
* configure test previewer to check `is item informational`;
* use title of the item as label.