### PR TITLE
Feature/CON-25/support Item Preview in topBlock component

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return [
     'label' => 'extension-tao-testqti-previewer',
     'description' => 'extension that provides QTI test previewer',
     'license'     => 'GPL-2.0',
-    'version' => '2.23.2',
+    'version' => '2.24.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'generis'      => '>=12.15.0',

--- a/views/js/previewer/component/topBlock/topBlock.js
+++ b/views/js/previewer/component/topBlock/topBlock.js
@@ -1,11 +1,12 @@
 define([
     'jquery',
     'lodash',
+    'i18n',
     'ui/component',
     'tpl!taoQtiTestPreviewer/previewer/component/topBlock/tpl/topBlock',
     'tpl!taoQtiTestPreviewer/previewer/component/topBlock/tpl/topBlockData',
     'css!taoQtiTestPreviewer/previewer/component/topBlock/css/topBlock',
-], function ($, _, componentFactory, topBlockTpl, topBlockDataTpl) {
+], function ($, _, __, componentFactory, topBlockTpl, topBlockDataTpl) {
     'use strict';
 
     /**
@@ -26,6 +27,7 @@ define([
             })
             .on('render', function () {
                 const $info = $(topBlockDataTpl({
+                    name: config.isTest ? __('Test Preview:') : __('Item Preview:'),
                     title: config.title
                 }));
                 const $element = this.getElement();

--- a/views/js/previewer/component/topBlock/tpl/topBlockData.tpl
+++ b/views/js/previewer/component/topBlock/tpl/topBlockData.tpl
@@ -1,1 +1,1 @@
-<p>{{__ "Test Preview:"}} <b>{{title}}</b></p>
+<p>{{name}} <b>{{title}}</b></p>


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/CON-25
https://github.com/oat-sa/extension-tao-test-preview-ui-loader/pull/12
https://github.com/oat-sa/extension-tao-item/pull/441
https://github.com/oat-sa/extension-tao-itemqti/pull/1585

The component `topBlock` was updated to support `Item Preview`

How to test:
- go to page Items
- click Preview
- check that preview uses new UI and top block displays 'Item Preview:'
- go to Item Authoring page
- click Preview
- check that preview uses new UI and top block displays 'Item Preview:'
![image](https://user-images.githubusercontent.com/25976342/99570701-6395aa80-29e3-11eb-8832-13a1491e32c4.png)
