### PR TITLE
Fix/CON-425/remove require tpl from npm package

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return [
     'label' => 'extension-tao-testqti-previewer',
     'description' => 'extension that provides QTI test previewer',
     'license'     => 'GPL-2.0',
-    'version' => '2.24.0',
+    'version' => '2.24.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'generis'      => '>=12.15.0',

--- a/views/js/previewer/plugins/button.tpl
+++ b/views/js/previewer/plugins/button.tpl
@@ -1,0 +1,19 @@
+<li
+    data-control="{{control}}"
+    class="small btn-info action{{#if className}} {{className}}{{/if}}"
+    title="{{title}}"
+    role="button"
+    {{#each aria}}
+        aria-{{@key}}="{{this}}"
+    {{/each}}
+>
+    <a
+        class="li-inner"
+        href="#"
+        onclick="return false"
+        aria-hidden="true"
+    >
+        {{#if icon}}<span class="icon icon-{{icon}}{{#unless text}} no-label{{/unless}}"></span>{{/if}}
+        {{#if text}}<span class="text">{{text}}</span>{{/if}}
+    </a>
+</li>

--- a/views/js/previewer/plugins/controls/close.js
+++ b/views/js/previewer/plugins/controls/close.js
@@ -27,7 +27,7 @@ define([
     'i18n',
     'ui/hider',
     'taoTests/runner/plugin',
-    'tpl!taoQtiTest/runner/plugins/templates/button'
+    'tpl!taoQtiTestPreviewer/previewer/plugins/button'
 ], function ($, _, __, hider, pluginFactory, buttonTpl) {
     'use strict';
 

--- a/views/js/previewer/plugins/navigation/submit/submit.js
+++ b/views/js/previewer/plugins/navigation/submit/submit.js
@@ -31,7 +31,7 @@ define([
     'util/strPad',
     'taoTests/runner/plugin',
     'taoQtiItem/qtiCommonRenderer/helpers/PciResponse',
-    'tpl!taoQtiTest/runner/plugins/templates/button',
+    'tpl!taoQtiTestPreviewer/previewer/plugins/button',
     'tpl!taoQtiTestPreviewer/previewer/plugins/navigation/submit/preview-console',
     'tpl!taoQtiTestPreviewer/previewer/plugins/navigation/submit/preview-console-line',
     'tpl!taoQtiTestPreviewer/previewer/plugins/navigation/submit/preview-console-closer'


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/CON-425

Add button.tpl from npm package to extension to have it in bundle.

How to test:
- build bundles `cd tao/views/build` then `npx grunt taoqtitestpreviewerbundle`
- set production mode in `config/generis.conf.php` to `define('DEBUG_MODE', false);`
- run tao
- go to Items page
- open devTools Network
- press Preview item
- check Network, no request for `button.tpl`