### PR TITLE
fix: AUT-26 show an item as informational if it does not have response declarations

### DIFF
--- a/models/test/mapper/TestPreviewMapper.php
+++ b/models/test/mapper/TestPreviewMapper.php
@@ -231,14 +231,14 @@ class TestPreviewMapper extends ConfigurableService implements TestPreviewMapper
 
     /**
      * @param $categories
-     * @param $itemRef
+     * @param AssessmentItemRef|ExtendedAssessmentItemRef $itemRef
      * @return bool
      */
     private function isItemInformational($categories, $itemRef): bool
     {
         $additionalCheck = false;
 
-        if ($itemRef instanceof ExtendedAssessmentItemRef && !count($itemRef->getResponseDeclarations())){
+        if (method_exists($itemRef, 'getResponseDeclarations') && !count($itemRef->getResponseDeclarations())) {
             $additionalCheck = true;
         }
         return $additionalCheck || in_array('x-tao-itemusage-informational', $categories, true);

--- a/models/test/mapper/TestPreviewMapper.php
+++ b/models/test/mapper/TestPreviewMapper.php
@@ -238,7 +238,7 @@ class TestPreviewMapper extends ConfigurableService implements TestPreviewMapper
     {
         $additionalCheck = false;
 
-        if (method_exists($itemRef, 'getResponseDeclarations') && !count($itemRef->getResponseDeclarations())) {
+        if (method_exists($itemRef, 'getResponseDeclarations') && empty($itemRef->getResponseDeclarations())) {
             $additionalCheck = true;
         }
         return $additionalCheck || in_array('x-tao-itemusage-informational', $categories, true);

--- a/models/test/mapper/TestPreviewMapper.php
+++ b/models/test/mapper/TestPreviewMapper.php
@@ -29,6 +29,7 @@ use oat\taoQtiTestPreviewer\models\test\TestPreviewConfig;
 use oat\taoQtiTestPreviewer\models\test\TestPreviewMap;
 use qtism\data\AssessmentItemRef;
 use qtism\data\AssessmentTest;
+use qtism\data\ExtendedAssessmentItemRef;
 use qtism\data\NavigationMode;
 use qtism\runtime\tests\Route;
 use qtism\runtime\tests\RouteItem;
@@ -106,7 +107,7 @@ class TestPreviewMapper extends ConfigurableService implements TestPreviewMapper
                 $isItemInformational = true;
 
                 if ($checkForInformationalItem) {
-                    $isItemInformational = $this->isItemInformational($itemInfos['categories']);
+                    $isItemInformational = $this->isItemInformational($itemInfos['categories'], $itemRef);
                     $itemInfos['informational'] = $isItemInformational;
                 }
 
@@ -230,11 +231,16 @@ class TestPreviewMapper extends ConfigurableService implements TestPreviewMapper
 
     /**
      * @param $categories
-     *
+     * @param $itemRef
      * @return bool
      */
-    private function isItemInformational($categories): bool
+    private function isItemInformational($categories, $itemRef): bool
     {
-        return in_array('x-tao-itemusage-informational', $categories, true);
+        $additionalCheck = false;
+
+        if ($itemRef instanceof ExtendedAssessmentItemRef && !count($itemRef->getResponseDeclarations())){
+            $additionalCheck = true;
+        }
+        return $additionalCheck || in_array('x-tao-itemusage-informational', $categories, true);
     }
 }

--- a/models/test/mapper/TestPreviewMapper.php
+++ b/models/test/mapper/TestPreviewMapper.php
@@ -238,7 +238,7 @@ class TestPreviewMapper extends ConfigurableService implements TestPreviewMapper
     {
         $additionalCheck = false;
 
-        if (method_exists($itemRef, 'getResponseDeclarations') && empty($itemRef->getResponseDeclarations())) {
+        if (method_exists($itemRef, 'getResponseDeclarations') && !count($itemRef->getResponseDeclarations())) {
             $additionalCheck = true;
         }
         return $additionalCheck || in_array('x-tao-itemusage-informational', $categories, true);


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/AUT-26
AC: the item should be considered as informational automatically if it has A-block in it.