### PR TITLE
[Fix] [Test Preview] - First item response is not saved in test preview

### DIFF
--- a/views/js/previewer/proxy/test.js
+++ b/views/js/previewer/proxy/test.js
@@ -111,6 +111,7 @@ define([
                 data.testContext = {
                     itemIdentifier: firstItem.identifier,
                     itemPosition: 0,
+                    itemSessionState: 0,
                     testPartId: firstItem.part,
                     sectionId: firstItem.section,
                     canMoveBackward: true,


### PR DESCRIPTION
**Ticket**

https://oat-sa.atlassian.net/browse/ADF-385

**Description**

When the user responses to the first item in Test Preview and navigate forward in the test, then goes back to the first item, he sees that the given response for the first item is not saved. If he sets the response again, it remains. 

**Steps to reproduce**

- Create a non-leaner test with several interactions in it;
- Preview the test from step 1;
- Response to the items;
- Go back to the first item.

**Actual result**

Response is cleared.

**Expected result**

Responses are saved during Test previewing.

**Environment**

In the ticket