### PR TITLE
fix: change word "item" for "Test" in test preview

### DIFF
--- a/views/js/previewer/adapter/test/qtiTest.js
+++ b/views/js/previewer/adapter/test/qtiTest.js
@@ -104,6 +104,7 @@ define([
                         topBlock = topBlockFactory(
                             window.document.body,
                             {
+                                isTest: testPreviewConfig.options.review.scope === 'test',
                                 title: runner.getTestMap().title,
                                 onClose: () =>  {
                                     runner.trigger('exit');


### PR DESCRIPTION
Related Issue: https://oat-sa.atlassian.net/browse/AUT-870
Preview mode in Tests  displays "Item" in preview mode.

Pre-requisite: To have a test created.

SETPS to test:

- Checkout to branch fix/AUT-870/item-instead-test-in-testPreview
- Login the env
- Go to Tests and press preview for a test
- **Actual result:** The preview top block displays "Items preview"
- **Expected result**: The preview top block displays "Test preview"

Testing env: http://test-silvia.playground.kitchen.it.taocloud.org:41441/