### PR TITLE
feat/AUT-1659/enable plugins from presets list in Test Preview

### DIFF
--- a/controller/TestPreviewer.php
+++ b/controller/TestPreviewer.php
@@ -28,6 +28,7 @@ use oat\tao\model\http\HttpJsonResponseTrait;
 use oat\taoQtiTestPreviewer\models\test\TestPreviewConfig;
 use oat\taoQtiTestPreviewer\models\test\service\TestPreviewer as TestPreviewerService;
 use oat\taoQtiTestPreviewer\models\test\TestPreviewRequest;
+use oat\taoQtiTestPreviewer\models\TestCategoryPresetMap;
 use oat\taoQtiTestPreviewer\models\testConfiguration\service\TestPreviewerConfigurationService;
 use tao_actions_ServiceModule;
 use Throwable;
@@ -59,6 +60,7 @@ class TestPreviewer extends tao_actions_ServiceModule
                     'testData' => [],
                     'testContext' => [],
                     'testMap' => $response->getMap()->getMap(),
+                    'presetMap' => $this->getTestPreviewerPresetsMapService()->getMap()
                 ]
             );
         } catch (Throwable $exception) {
@@ -103,5 +105,10 @@ class TestPreviewer extends tao_actions_ServiceModule
     private function getTestPreviewerService(): TestPreviewerService
     {
         return $this->getServiceLocator()->get(TestPreviewerService::class);
+    }
+
+    private function getTestPreviewerPresetsMapService(): TestCategoryPresetMap
+    {
+        return $this->getPsrContainer()->get(TestCategoryPresetMap::class);
     }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -20,6 +20,7 @@
 
 use oat\taoItems\model\user\TaoItemsRoles;
 use oat\tao\model\accessControl\func\AccessRule;
+use oat\taoQtiTestPreviewer\models\ServiceProvider\QtiTestPreviewerServiceProvider;
 use oat\taoQtiTestPreviewer\scripts\update\Updater;
 use oat\taoQtiTestPreviewer\scripts\install\RegisterPreviewers;
 use oat\taoQtiTestPreviewer\scripts\install\RegisterTestPreviewer;
@@ -87,5 +88,8 @@ return [
     ],
     'extra' => [
         'structures' => __DIR__ . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR . 'structures.xml',
-    ]
+    ],
+    'containerServiceProviders' => [
+        QtiTestPreviewerServiceProvider::class,
+    ],
 ];

--- a/models/ServiceProvider/QtiTestPreviewerServiceProvider.php
+++ b/models/ServiceProvider/QtiTestPreviewerServiceProvider.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);

--- a/models/ServiceProvider/QtiTestPreviewerServiceProvider.php
+++ b/models/ServiceProvider/QtiTestPreviewerServiceProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTestPreviewer\models\ServiceProvider;
+
+use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use oat\taoQtiTest\models\TestCategoryPresetProvider;
+use oat\taoQtiTestPreviewer\models\TestCategoryPresetMap;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+class QtiTestPreviewerServiceProvider implements ContainerServiceProviderInterface
+{
+    public function __invoke(ContainerConfigurator $configurator): void
+    {
+        $services = $configurator->services();
+
+        $services
+            ->set(TestCategoryPresetMap::class, TestCategoryPresetMap::class)
+            ->public()
+            ->args(
+                [
+                    service(TestCategoryPresetProvider::SERVICE_ID),
+                ]
+            );
+    }
+}

--- a/models/TestCategoryPresetMap.php
+++ b/models/TestCategoryPresetMap.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);
@@ -25,7 +25,6 @@ namespace oat\taoQtiTestPreviewer\models;
 use oat\oatbox\log\LoggerAwareTrait;
 use oat\taoQtiTest\models\TestCategoryPreset;
 use oat\taoQtiTest\models\TestCategoryPresetProvider;
-use RuntimeException;
 
 class TestCategoryPresetMap
 {

--- a/models/TestCategoryPresetMap.php
+++ b/models/TestCategoryPresetMap.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTestPreviewer\models;
+
+use oat\oatbox\log\LoggerAwareTrait;
+use oat\taoQtiTest\models\TestCategoryPreset;
+use oat\taoQtiTest\models\TestCategoryPresetProvider;
+use RuntimeException;
+
+class TestCategoryPresetMap
+{
+    use LoggerAwareTrait;
+
+    /** @var TestCategoryPresetProvider */
+    private $testCategoryPresetProvider;
+
+    public function __construct(TestCategoryPresetProvider $testCategoryPresetProvider)
+    {
+        $this->testCategoryPresetProvider = $testCategoryPresetProvider;
+    }
+
+    public function getMap(): array
+    {
+        $presetList = $this->testCategoryPresetProvider
+            ->findPresetGroupOrFail(TestCategoryPresetProvider::GROUP_TOOLS);
+
+        $presetMap = [];
+        /** @var TestCategoryPreset $preset */
+        foreach ($presetList['presets'] as $preset) {
+            $presetMap[] = [$preset->getId() => $preset->getQtiCategory()];
+        }
+
+        return $presetMap;
+    }
+}

--- a/test/unit/models/TestCategoryPresetMapTest.php
+++ b/test/unit/models/TestCategoryPresetMapTest.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);

--- a/test/unit/models/TestCategoryPresetMapTest.php
+++ b/test/unit/models/TestCategoryPresetMapTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoQtiTestPreviewer\test\unit\models;
+
+use oat\generis\test\MockObject;
+use oat\generis\test\TestCase;
+use oat\oatbox\log\LoggerService;
+use oat\taoQtiTest\models\TestCategoryPreset;
+use oat\taoQtiTest\models\TestCategoryPresetProvider;
+use oat\taoQtiTestPreviewer\models\TestCategoryPresetMap;
+use RuntimeException;
+
+class TestCategoryPresetMapTest extends TestCase
+{
+
+    /** @var TestCategoryPresetProvider|MockObject */
+    private $testCategoryPresetProviderMock;
+
+    /** @var TestCategoryPreset */
+    private $subject;
+
+    /** @var TestCategoryPreset|MockObject */
+    private $testCategoryPresetMock;
+
+    public function setUp(): void
+    {
+        $this->testCategoryPresetProviderMock = $this->createMock(TestCategoryPresetProvider::class);
+        $this->testCategoryPresetMock = $this->createMock(TestCategoryPreset::class);
+        $this->subject = new TestCategoryPresetMap(
+            $this->testCategoryPresetProviderMock
+        );
+    }
+
+    public function testGetMap(): void
+    {
+        $this->testCategoryPresetProviderMock
+            ->expects($this->once())
+            ->method('findPresetGroupOrFail')
+            ->willReturn([
+                $this->testCategoryPresetProviderMock
+            ]);
+
+        $this->testCategoryPresetMock
+            ->expects($this->once())
+            ->method('getId')
+            ->willReturn('presetId');
+
+        $this->testCategoryPresetMock
+            ->expects($this->once())
+            ->method('getQtiCategory')
+            ->willReturn('qtiCategory');
+
+        $this->assertSame([
+            ['presetId' => 'qtiCategory']
+        ], $this->subject->getMap());
+    }
+
+    public function testGetMapFailed(): void
+    {
+        $this->testCategoryPresetProviderMock
+            ->expects($this->once())
+            ->method('findPresetGroupOrFail')
+            ->willThrowException(new RuntimeException());
+
+        $result = $this->subject->getMap();
+    }
+}

--- a/test/unit/models/TestCategoryPresetMapTest.php
+++ b/test/unit/models/TestCategoryPresetMapTest.php
@@ -24,11 +24,9 @@ namespace oat\taoQtiTestPreviewer\test\unit\models;
 
 use oat\generis\test\MockObject;
 use oat\generis\test\TestCase;
-use oat\oatbox\log\LoggerService;
 use oat\taoQtiTest\models\TestCategoryPreset;
 use oat\taoQtiTest\models\TestCategoryPresetProvider;
 use oat\taoQtiTestPreviewer\models\TestCategoryPresetMap;
-use RuntimeException;
 
 class TestCategoryPresetMapTest extends TestCase
 {
@@ -57,7 +55,9 @@ class TestCategoryPresetMapTest extends TestCase
             ->expects($this->once())
             ->method('findPresetGroupOrFail')
             ->willReturn([
-                $this->testCategoryPresetProviderMock
+                'presets' => [
+                    $this->testCategoryPresetMock
+                ]
             ]);
 
         $this->testCategoryPresetMock
@@ -73,15 +73,5 @@ class TestCategoryPresetMapTest extends TestCase
         $this->assertSame([
             ['presetId' => 'qtiCategory']
         ], $this->subject->getMap());
-    }
-
-    public function testGetMapFailed(): void
-    {
-        $this->testCategoryPresetProviderMock
-            ->expects($this->once())
-            ->method('findPresetGroupOrFail')
-            ->willThrowException(new RuntimeException());
-
-        $result = $this->subject->getMap();
     }
 }

--- a/test/unit/models/TestCategoryPresetMapTest.php
+++ b/test/unit/models/TestCategoryPresetMapTest.php
@@ -74,4 +74,16 @@ class TestCategoryPresetMapTest extends TestCase
             ['presetId' => 'qtiCategory']
         ], $this->subject->getMap());
     }
+
+    public function testGetMapEmpty(): void
+    {
+        $this->testCategoryPresetProviderMock
+            ->expects($this->once())
+            ->method('findPresetGroupOrFail')
+            ->willReturn([
+                'presets' => []
+            ]);
+
+        $this->assertSame([], $this->subject->getMap());
+    }
 }

--- a/views/js/previewer/proxy/test.js
+++ b/views/js/previewer/proxy/test.js
@@ -71,19 +71,20 @@ define([
     function updateTestContextWithItem(testMap, position, testContext, presetMap) {
         const jump = mapHelper.getJump(testMap, position);
         const item = mapHelper.getItemAt(testMap, position);
-        if (item) {
-            testContext.testPartId = jump.part;
-            testContext.sectionId = jump.section;
-            testContext.itemIdentifier = jump.identifier;
-            testContext.itemSessionState = itemSessionStates.initial;
-            testContext.options = createContextOptions(item, presetMap);
+        if (!item) {
+            return;
         }
+        testContext.testPartId = jump.part;
+        testContext.sectionId = jump.section;
+        testContext.itemIdentifier = jump.identifier;
+        testContext.itemSessionState = itemSessionStates.initial;
+        testContext.options = createContextOptions(item, presetMap);
     }
     /**
      * Convert preset categories to context.options
      * @param {Object} item
      * @param {Array} presetMap
-     * @returns {Object} properties
+     * @returns {Object} options
      */
     function createContextOptions(item, presetMap) {
         const options = {};

--- a/views/js/previewer/proxy/test.js
+++ b/views/js/previewer/proxy/test.js
@@ -130,7 +130,7 @@ define([
                 const data = response.data;
                 //the received map is not complete and should be "built"
                 this.builtTestMap = mapHelper.reindex(data.testMap);
-                this.presetMap = data.presetMap;
+                this.presetMap = data.presetMap || [];
                 delete data.presetMap;
                 const firstJump = this.builtTestMap.jumps[0] || {};
                 const firstItem = mapHelper.getItemAt(this.builtTestMap, 0);


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1659
**BE part:**
TestPreviewer::init will now include `presetList` variable that will map all tools available and their map to QTI categories
**FE part:** 
on actions testContext.properties updated using preset categories to enable plugins in Test Preview

**How to test:**
- create test
- add item
- enable some plugins for item (Test-taker tools)
- save and go to test preview
- plugins should be enabled

![image](https://user-images.githubusercontent.com/25976342/148214498-a3a55754-c7a8-43cd-886f-65a9ddef338b.png)
![image](https://user-images.githubusercontent.com/25976342/148214571-88479888-4865-4ade-b3c9-460f0bb3a9da.png)

