### PR TITLE
fix: skip the Qti validation during the test preview

### DIFF
--- a/controller/Previewer.php
+++ b/controller/Previewer.php
@@ -148,7 +148,7 @@ class Previewer extends ServiceModule
                     return;
                 }
 
-                $packer = new Packer($item, $lang);
+                $packer = new Packer($item, $lang, true);
                 $packer->setServiceLocator($this->getServiceLocator());
 
                 $itemPack = $packer->pack();


### PR DESCRIPTION
There is no point to do this validation on the test preview as the same validation is done when saving the item.
This unnecessary validation was also increasing the response time to seconds instead of milliseconds.
This is another reason to avoid it during the test previewer.

Refs: https://oat-sa.atlassian.net/browse/AUT-1822

## How to test.
1. Login on TAO Platform
2. Go to tests
3. Select a test
4. Click on Preview

Expected result:
Endpoint /taoQtiTestPreviewer/Previewer/getItem should take milliseconds to return the response
Actual result:
Endpoint /taoQtiTestPreviewer/Previewer/getItem takes seconds to return the response
