### PR TITLE
fix: html decode test and section titles

### DIFF
--- a/models/test/mapper/TestPreviewMapper.php
+++ b/models/test/mapper/TestPreviewMapper.php
@@ -53,7 +53,7 @@ class TestPreviewMapper extends ConfigurableService implements TestPreviewMapper
         $forceInformationalTitles = $config->get(TestPreviewConfig::REVIEW_FORCE_INFORMATION_TITLE);
         $displaySubsectionTitle = $config->get(TestPreviewConfig::REVIEW_DISPLAY_SUBSECTION_TITLE) ?? true;
 
-        $map['title'] = $test->getTitle();
+        $map['title'] = html_entity_decode($test->getTitle());
         $map['identifier'] = $test->getIdentifier();
         $map['className'] = $test->getQtiClassName();
         $map['toolName'] = $test->getToolName();
@@ -134,7 +134,7 @@ class TestPreviewMapper extends ConfigurableService implements TestPreviewMapper
 
                 if (!isset($map['parts'][$partId]['sections'][$sectionId])) {
                     $map['parts'][$partId]['sections'][$sectionId]['id'] = $sectionId;
-                    $map['parts'][$partId]['sections'][$sectionId]['label'] = $section->getTitle();
+                    $map['parts'][$partId]['sections'][$sectionId]['label'] = html_entity_decode($section->getTitle());
                     $map['parts'][$partId]['sections'][$sectionId]['isCatAdaptive'] = false; //@TODO Implement as feature
                     $map['parts'][$partId]['sections'][$sectionId]['position'] = $offset;
 


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/AUT-2073

### Description

Test entity is persisted into xml representation, so it requires to store html entities encoded. So `&` is translated into `&amp;`
When xml doc containing test is parsed back, reverse decoding doesn't happen during marshalling `vendor/qtism/qtism/qtism/data/storage/xml/marshalling/AssessmentTestMarshaller.php`, so value is being read as is and passed into json response of previewer `init` endpoint.

[QTI Information model](https://www.imsglobal.org/question/qtiv2p2p2/QTIv2p2p2-ASI-InformationModelv1p0/imsqtiv2p2p2_asi_v1p0_InfoModelv1p0.html#RootCharacteristic_AssessmentTest.Attr_title) doesn't restrict that chars for title property which is of type `NormalizedString`

### How to test

Env: https://aut-2073.playground.kitchen.it.taocloud.org/ 

 - Create/edit test and set title containing some chars like `&`, `<`, `"`
 - Save the test
 - Open test to edit it, open preview, check title is ok
