### PR TITLE
Feature/tr 4339/custom theme in previewer from configuration endpoint

### DIFF
--- a/models/testConfiguration/mapper/TestPreviewerConfigurationMapper.php
+++ b/models/testConfiguration/mapper/TestPreviewerConfigurationMapper.php
@@ -37,9 +37,11 @@ class TestPreviewerConfigurationMapper extends ConfigurableService
      *
      * @return TestPreviewerConfig
      */
-    public function map(array $providerModules, array $plugins, array $options): TestPreviewerConfig
+    public function map(array $providerModules, array $plugins, array $testRunnerOptions, array $testPreviewerOptions): TestPreviewerConfig
     {
-        return new TestPreviewerConfig($this->getActiveProviders($providerModules, $plugins), $options);
+        return new TestPreviewerConfig(
+            $this->getActiveProviders($providerModules, $plugins),
+            $this->getCombinedOptions($testRunnerOptions, $testPreviewerOptions));
     }
 
     /**
@@ -83,5 +85,18 @@ class TestPreviewerConfigurationMapper extends ConfigurableService
         }
 
         return $result;
+    }
+
+    private function getCombinedOptions(array $testRunnerOptions, array $testPreviewerOptions): array
+    {
+        //specify theme - override test-runner config for itemThemeSwitcher plugin with test-previewer's own config
+        if (isset($testPreviewerOptions['plugins']) && isset($testPreviewerOptions['plugins']['itemThemeSwitcher'])) {
+            if (!isset($testRunnerOptions['plugins'])) {
+                $testRunnerOptions['plugins'] = array([]);
+            }
+            $testRunnerOptions['plugins']['itemThemeSwitcher'] = $testPreviewerOptions['plugins']['itemThemeSwitcher'];
+        }
+
+        return $testRunnerOptions;
     }
 }

--- a/models/testConfiguration/service/TestPreviewerConfigurationService.php
+++ b/models/testConfiguration/service/TestPreviewerConfigurationService.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace oat\taoQtiTestPreviewer\models\testConfiguration\service;
 
+use common_ext_ExtensionsManager;
 use oat\oatbox\service\ConfigurableService;
 use oat\taoQtiTest\models\runner\config\QtiRunnerConfig;
 use oat\taoQtiTestPreviewer\models\testConfiguration\mapper\TestPreviewerConfigurationMapper;
@@ -36,7 +37,8 @@ class TestPreviewerConfigurationService extends ConfigurableService
         return $this->getMapper()->map(
             $this->getProviderService()->getAllProviders(),
             $this->getTestRunnerPluginService()->getAllPlugins(),
-            $this->getTestRunnerConfigurationService()->getConfig()
+            $this->getTestRunnerConfigurationService()->getConfig(),
+            $this->getTestPreviewerConfig()
         );
     }
 
@@ -53,6 +55,14 @@ class TestPreviewerConfigurationService extends ConfigurableService
     private function getTestRunnerConfigurationService(): QtiRunnerConfig
     {
         return $this->getServiceLocator()->get(QtiRunnerConfig::SERVICE_ID);
+    }
+
+    private function getTestPreviewerConfig(): array
+    {
+        $extensionsManager = $this->getServiceLocator()->get(common_ext_ExtensionsManager::SERVICE_ID);
+        $extension = $extensionsManager->getExtensionById('taoQtiTestPreviewer');
+        $rawTestPreviewerConfig = $extension->getConfig('TestPreviewer');
+        return $rawTestPreviewerConfig;
     }
 
     private function getMapper(): TestPreviewerConfigurationMapper


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-4339

**ALTERNATIVE CONFIG SOLUTION**

Base composer: https://github.com/oat-sa/tao-enterprise-nfer-enot/tree/2022.05.1 with:
- https://github.com/oat-sa/nfer-enot-template/pull/63
- https://github.com/oat-sa/extension-tao-testqti-previewer/pull/169

**TEST PREVIEW:**
- theme definition is already loaded: `https://tao-nferenot.docker.localhost/tao/ClientConfig/config?extension=tao&module=Main&action=index&shownExtension=taoTests&shownStructure=tests`  has `ui/themes` object
- [itemThemeSwitcher](https://github.com/oat-sa/tao-test-runner-qti-fe/blob/master/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js) plugin that loads theme is enabled for this customer. It's only ['item' theme](https://github.com/oat-sa/nfer-enot-template/tree/develop/views/scss/themes/items/enotMaths), not ['platform' theme](https://github.com/oat-sa/nfer-enot-template/tree/develop/views/scss/themes/platform/enot-maths), but that seems enough. (PS: Platform theme for delivery is added [here](https://github.com/oat-sa/extension-tao-delivery/blob/master/views/templates/DeliveryServer/layout.tpl#L21))
- [configuration endpoint](https://github.com/oat-sa/extension-tao-testqti-previewer/blob/develop/controller/TestPreviewer.php#L75) is already [called](https://github.com/oat-sa/extension-tao-testqti-previewer/blob/develop/views/js/previewer/adapter/test/qtiTest.js#L66)
- need to define which theme to use somewhere and pass it in response to configuration endpoint. I added new config file:
```
---> tao-enterprise-nfer-enot\config\taoQtiTestPreviewer\TestPreviewer.conf.php
<?php
return new oat\oatbox\config\ConfigurationService(array(
    'config' => array(
        'plugins' =>  array(
            'itemThemeSwitcher' => array(
                'activeNamespace' => 'nferEnotThemeEnotMaths'
            )
        )
    )
));
```

**ITEM PREVIEW:**
- theme definition is already loaded: `https://tao-nferenot.docker.localhost/tao/ClientConfig/config?extension=tao&module=Main&action=index&shownExtension=taoTests&shownStructure=tests`  has `ui/themes` object
- [itemThemeSwitcher](https://github.com/oat-sa/tao-test-runner-qti-fe/blob/master/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js) plugin that loads item theme is [enabled for item preview](https://github.com/oat-sa/extension-tao-testqti-previewer/blob/develop/views/js/previewer/adapter/item/qtiItem.js#L48)
- need to pass configuration to item-runner-factory used in Item Preview. Added [new configuration endpoint](https://github.com/oat-sa/extension-tao-testqti-previewer/blob/feature/TR-4339/custom-theme-in-previewer/views/js/previewer/adapter/item/qtiItem.js#L85). An additional request on each item preview for everyone...
 - need to define which theme to use somewhere and pass it in response to configuration endpoint. I added new config file:
```
---> tao-enterprise-nfer-enot\config\taoQtiTestPreviewer\ItemPreviewer.conf.php
<?php
return new oat\oatbox\config\ConfigurationService(array(
    'config' => array(
        'pluginsOptions' =>  array(
            'itemThemeSwitcher' => array(
                'activeNamespace' => 'nferEnotThemeEnotMaths'
            )
        )
    )
));
```


**TODO:**
- migration for config
- do not fail if config settings are not there (add more checks for undefined)
- default config
- unit test