### PR TITLE
Feature/tr 4339/custom theme in previewer from ClientConfig

### DIFF
--- a/views/js/previewer/adapter/test/qtiTest.js
+++ b/views/js/previewer/adapter/test/qtiTest.js
@@ -59,8 +59,8 @@ define([
 
     const transformConfiguration = config => {
         const plugins = Array.isArray(config.plugins) ? [...defaultPlugins, ...config.plugins] : defaultPlugins;
-        const {view, readOnly, fullPage, hideActionBars} = config;
-        const options = _.omit({view, readOnly, fullPage, hideActionBars}, _.isUndefined);
+        const { view, readOnly, fullPage, hideActionBars, pluginsOptions } = config;
+        const options = _.omit({ view, readOnly, fullPage, hideActionBars }, _.isUndefined);
 
         return request({
             url: urlUtil.route('configuration', testPreviewerController, taoExtension),
@@ -69,7 +69,15 @@ define([
             const configuration = response.data;
 
             configuration.providers.plugins = [...configuration.providers.plugins, ...plugins];
+
             _.assign(configuration.options, options);
+
+            if (pluginsOptions) {
+                if (!configuration.options.plugins) {
+                    configuration.options.plugins = {};
+                }
+                _.assign(configuration.options.plugins, pluginsOptions);
+            }
 
             return configuration;
         });


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-4339

Base composer: see TAE branch in PR: https://oat-sa.atlassian.net/browse/TR-4339?focusedCommentId=191355

**TEST PREVIEW:**
- theme definition is already loaded: `https://tao-nferenot.docker.localhost/tao/ClientConfig/config?extension=tao&module=Main&action=index&shownExtension=taoTests&shownStructure=tests`  has `ui/themes` object
- [itemThemeSwitcher](https://github.com/oat-sa/tao-test-runner-qti-fe/blob/master/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js) plugin that loads theme is enabled for this customer. It's only ['item' theme](https://github.com/oat-sa/nfer-enot-template/tree/develop/views/scss/themes/items/enotMaths), not ['platform' theme](https://github.com/oat-sa/nfer-enot-template/tree/develop/views/scss/themes/platform/enot-maths), but that seems enough. (PS: Platform theme for delivery is added [here](https://github.com/oat-sa/extension-tao-delivery/blob/master/views/templates/DeliveryServer/layout.tpl#L21))
 - need to define which theme to use: in [module config](https://github.com/oat-sa/tao-core/blob/master/views/templates/client_config.tpl) `config\tao\client_lib_config_registry.conf.php` 

**ITEM PREVIEW:**
- theme definition is already loaded: `https://tao-nferenot.docker.localhost/tao/ClientConfig/config?extension=tao&module=Main&action=index&shownExtension=taoTests&shownStructure=tests`  has `ui/themes` object
- [itemThemeSwitcher](https://github.com/oat-sa/tao-test-runner-qti-fe/blob/master/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js) plugin that loads item theme is [enabled for item preview](https://github.com/oat-sa/extension-tao-testqti-previewer/blob/develop/views/js/previewer/adapter/item/qtiItem.js#L48)
 - need to define which theme to use: in [module config](https://github.com/oat-sa/tao-core/blob/master/views/templates/client_config.tpl) `config\tao\client_lib_config_registry.conf.php` 
