### PR TITLE
Fix/TR-4212/Revert unneeded decoding of HTML entities

### DIFF
--- a/models/test/mapper/TestPreviewMapper.php
+++ b/models/test/mapper/TestPreviewMapper.php
@@ -53,7 +53,7 @@ class TestPreviewMapper extends ConfigurableService implements TestPreviewMapper
         $forceInformationalTitles = $config->get(TestPreviewConfig::REVIEW_FORCE_INFORMATION_TITLE);
         $displaySubsectionTitle = $config->get(TestPreviewConfig::REVIEW_DISPLAY_SUBSECTION_TITLE) ?? true;
 
-        $map['title'] = html_entity_decode($test->getTitle());
+        $map['title'] = $test->getTitle();
         $map['identifier'] = $test->getIdentifier();
         $map['className'] = $test->getQtiClassName();
         $map['toolName'] = $test->getToolName();
@@ -134,7 +134,7 @@ class TestPreviewMapper extends ConfigurableService implements TestPreviewMapper
 
                 if (!isset($map['parts'][$partId]['sections'][$sectionId])) {
                     $map['parts'][$partId]['sections'][$sectionId]['id'] = $sectionId;
-                    $map['parts'][$partId]['sections'][$sectionId]['label'] = html_entity_decode($section->getTitle());
+                    $map['parts'][$partId]['sections'][$sectionId]['label'] = $section->getTitle();
                     $map['parts'][$partId]['sections'][$sectionId]['isCatAdaptive'] = false; //@TODO Implement as feature
                     $map['parts'][$partId]['sections'][$sectionId]['position'] = $offset;
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-4212

Revert the fix added by #167 for [AUT-2073](https://oat-sa.atlassian.net/browse/AUT-2073).
It is not needed anymore to decode the HTML entities from the XML attributes since it is fixed inside QTI-SDK (see: https://github.com/oat-sa/qti-sdk/pull/325).

How to test:
 - Create/edit a test and set a title containing some chars like `&`, `<`, `"`
 - Save the test (look at the XML file generated  at `data/taoQtiTest`)
 - Preview the test, and check the symbols added to the title are properly displayed
