### PR TITLE
fix: skip the Qti validation during the test preview

### DIFF
--- a/controller/Previewer.php
+++ b/controller/Previewer.php
@@ -148,7 +148,7 @@ class Previewer extends ServiceModule
                     return;
                 }
 
-                $packer = new Packer($item, $lang);
+                $packer = new Packer($item, $lang, true);
                 $packer->setServiceLocator($this->getServiceLocator());
 
                 $itemPack = $packer->pack();


### PR DESCRIPTION
Backport for https://github.com/oat-sa/extension-tao-testqti-previewer/pull/157
There is no point to do this validation on the test preview as the same validation is done when saving the item. This unnecessary validation was also increasing the response time to seconds instead of milliseconds. This is another reason to avoid it during the test previewer.

Refs: https://oat-sa.atlassian.net/browse/AUT-1822 (cherry picked from commit 781dfed84e4f112867e63c43a1a604bf26ba84e4)