### PR TITLE
fix/AUT-2673/display-image-inline-block

### DIFF
--- a/views/js/previewer/provider/item/item.js
+++ b/views/js/previewer/provider/item/item.js
@@ -305,7 +305,7 @@ define([
                                 parent.addClass(`parent-${alignmentHelper.INLINE_CLASS}`);
                             } else if (
                                 // on Passage
-                                Object.values(this._item.bdy.elements).some(el => el.bdy.elements
+                                Object.values(this._item.bdy.elements).some(el => el.bdy && el.bdy.elements
                                     && Object.keys(el.bdy.elements).length
                                     && Object.values(el.bdy.elements).some(els => els.attr('class') === alignmentHelper.INLINE_CLASS)
                                 )

--- a/views/js/previewer/provider/item/item.js
+++ b/views/js/previewer/provider/item/item.js
@@ -34,7 +34,8 @@ define([
     'taoQtiTest/runner/config/assetManager',
     'taoItems/assets/strategies',
     'taoQtiItem/qtiCommonRenderer/helpers/container',
-    'tpl!taoQtiTestPreviewer/previewer/provider/item/tpl/item'
+    'tpl!taoQtiTestPreviewer/previewer/provider/item/tpl/item',
+    'ui/mediaEditor/plugins/mediaAlignment/helper'
 ], function (
     $,
     _,
@@ -48,7 +49,8 @@ define([
     assetManagerFactory,
     assetStrategies,
     containerHelper,
-    layoutTpl
+    layoutTpl,
+    alignmentHelper
 ) {
     'use strict';
 
@@ -294,6 +296,25 @@ define([
                     .on('render', function onItemRunnerRender() {
                         this.on('responsechange', changeState);
                         this.on('statechange', changeState);
+
+                        // if there is a Figure with inline aligment
+                        if (this._item.bdy && this._item.bdy.elements && Object.keys(this._item.bdy.elements).length) {
+                            // on Item
+                            if (Object.values(this._item.bdy.elements).some(el => el.attr('class') === alignmentHelper.INLINE_CLASS)) {
+                                const parent = $(this.container).find(`.${alignmentHelper.INLINE_CLASS}`).parent().parent();
+                                parent.addClass(`parent-${alignmentHelper.INLINE_CLASS}`);
+                            } else if (
+                                // on Passage
+                                Object.values(this._item.bdy.elements).some(el => el.bdy.elements
+                                    && Object.keys(el.bdy.elements).length
+                                    && Object.values(el.bdy.elements).some(els => els.attr('class') === alignmentHelper.INLINE_CLASS)
+                                )
+                            ) {
+                                const parent = $(this.container).find(`.${alignmentHelper.INLINE_CLASS}`).parent().parent();
+                                parent.addClass(`parent-${alignmentHelper.INLINE_CLASS}`);
+                            }
+                        }
+
                         resolve();
                     })
                     .init();


### PR DESCRIPTION
**Related to:** [AUT-2673](https://oat-sa.atlassian.net/browse/AUT-2673)

**Description:**
Display Image inline on Figure tag

**Changes:**
The Figure tag is a block tag, so the better approach is to fake the flow with CSS.
- Add a `display: flex` property to the Feature and siblings elements wrapper, forcing the inline flow.

**Companion PRs**
- https://github.com/oat-sa/tao-core/pull/3654
- https://github.com/oat-sa/extension-tao-itemqti/pull/2256

**How to check:**

**On Assets** 
- Create an Asset with a text block. Add in the middle of the text an image. Play with the inline panel controls of the image to check if it is positioned correctly.
- Check Preview.

**On Items**
- Repeat the previous step on Assets.
- Add the previously created Asset with the Figure image on the inline position to check the position of the Asset image inside the Item.
- Check Preview

**On Tests**
- Pending Preview ⚠️ 
