### PR TITLE
fix: catch error about deleted item and change message

### DIFF
--- a/views/js/previewer/proxy/test.js
+++ b/views/js/previewer/proxy/test.js
@@ -157,10 +157,12 @@ define([
             .catch(e => {
                 // error from old system
                 // \oat\tao\model\http\HttpJsonResponseTrait::setErrorJsonResponse for standard response
-                // that doesn't contains errorCode and printed as '400: error'
+                // in vendor/qtism/qtism/qtism/data/storage/xml/XmlCompactDocument.php
+                // "An error occurred while unreferencing item reference with identifier  "
+                // response doesn't contains errorCode and printed as '400: error'
                 // see function createError from @oat-sa/tao-core-sdk/src/core/request.js
-                // to have meaningfull error copy original message from response
-                if (e.response && e.response.message && /An error occurred while unreferencing item reference/.test(e.response.message)) {
+                // check message from response and replace by meaningful message
+                if (e.response && e.response.message && /An error occurred while unreferencing item reference with identifier/.test(e.response.message)) {
                     throw Error(__('It seems that some items have been deleted. Please remove the items with empty labels from the test and save before trying again.'));
                 } else {
                     throw e;

--- a/views/js/previewer/proxy/test.js
+++ b/views/js/previewer/proxy/test.js
@@ -22,12 +22,13 @@
  * @author Hanna Dzmitryieva <hanna@taotesting.com>
  */
 define([
+    'i18n',
     'core/promiseQueue',
     'core/request',
     'util/url',
     'taoQtiTest/runner/helpers/map',
     'taoQtiTestPreviewer/previewer/proxy/itemDataHandlers'
-], function (promiseQueue, request, urlUtil, mapHelper, itemDataHandlers) {
+], function (__, promiseQueue, request, urlUtil, mapHelper, itemDataHandlers) {
     'use strict';
 
     const serviceControllerInit = 'TestPreviewer';
@@ -152,6 +153,18 @@ define([
                     allowSkipping: firstItem.allowSkipping
                 };
                 return data;
+            })
+            .catch(e => {
+                // error from old system
+                // \oat\tao\model\http\HttpJsonResponseTrait::setErrorJsonResponse for standard response
+                // that doesn't contains errorCode and printed as '400: error'
+                // see function createError from @oat-sa/tao-core-sdk/src/core/request.js
+                // to have meaningfull error copy original message from response
+                if (e.response && e.response.message && /An error occurred while unreferencing item reference/.test(e.response.message)) {
+                    throw Error(__('It seems that some items have been deleted. Please remove the items with empty labels from the test and save before trying again.'));
+                } else {
+                    throw e;
+                }
             });
         },
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1010

**How to test:**

- create items
- create test with items
- go to Items and delete one or more items
- try to Preview test
- check error message

<img width="712" alt="image" src="https://user-images.githubusercontent.com/25976342/219599262-79a6563e-af4d-4b0b-a82b-3e05e9320757.png">
