### PR TITLE
fix: validate the access to preview a test

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,2 +1,2 @@
 remote_config:
-    url: 'https://raw.githubusercontent.com/oat-sa/tao-code-quality/refs/heads/main/coderabbit/php/authoring/v1/.coderabbit.yaml'
+    url: 'https://raw.githubusercontent.com/oat-sa/tao-code-quality/main/coderabbit/php/authoring/v1/.coderabbit.yaml'

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,2 @@
+remote_config:
+    url: 'https://raw.githubusercontent.com/oat-sa/tao-code-quality/refs/heads/main/coderabbit/php/authoring/v1/.coderabbit.yaml'

--- a/controller/TestPreviewer.php
+++ b/controller/TestPreviewer.php
@@ -24,7 +24,9 @@ namespace oat\taoQtiTestPreviewer\controller;
 
 use common_exception_UserReadableException;
 use InvalidArgumentException;
+use oat\tao\model\accessControl\PermissionChecker;
 use oat\tao\model\http\HttpJsonResponseTrait;
+use oat\tao\model\resources\ResourceAccessDeniedException;
 use oat\taoQtiTestPreviewer\models\test\TestPreviewConfig;
 use oat\taoQtiTestPreviewer\models\test\service\TestPreviewer as TestPreviewerService;
 use oat\taoQtiTestPreviewer\models\test\TestPreviewRequest;
@@ -42,13 +44,18 @@ class TestPreviewer extends tao_actions_ServiceModule
     {
         try {
             $requestParams = $this->getPsrRequest()->getQueryParams();
+            $testUri = $requestParams['testUri'] ?? null;
 
-            if (empty($requestParams['testUri'])) {
+            if (empty($testUri)) {
                 throw  new InvalidArgumentException('Required `testUri` param is missing ');
             }
 
+            if (!$this->getPermissionChecker()->hasReadAccess($testUri)) {
+                throw new ResourceAccessDeniedException($testUri);
+            }
+
             $testPreviewRequest = new TestPreviewRequest(
-                $requestParams['testUri'],
+                $testUri,
                 new TestPreviewConfig([TestPreviewConfig::CHECK_INFORMATIONAL => true])
             );
             $response = $this->getTestPreviewerService()->createPreview($testPreviewRequest);
@@ -130,5 +137,10 @@ class TestPreviewer extends tao_actions_ServiceModule
             );
         }
         return $exception->getMessage();
+    }
+
+    private function getPermissionChecker(): PermissionChecker
+    {
+        return $this->getPsrContainer()->get(PermissionChecker::class);
     }
 }


### PR DESCRIPTION
## Ticket:

https://oat-sa.atlassian.net/browse/ADF-1976

## What's Changed

- Access to preview is validated now

## Dependencies PRs

- https://github.com/oat-sa/extension-tao-test/pull/506

## How to test

- Remove user access from a test and try to preview it

![Screenshot 2025-06-04 at 18 04 53](https://github.com/user-attachments/assets/853a461f-aeb3-4e38-b52e-c2d19d977a4a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced access control for test preview, restricting access to authorized users only.

- **Chores**
  - Added configuration for remote code quality settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->