### PR TITLE
Feature/tr 6795/external qti previewer 2

### DIFF
--- a/controller/Previewer.php
+++ b/controller/Previewer.php
@@ -322,7 +322,7 @@ class Previewer extends ServiceModule
                 true,
                 flags: JSON_THROW_ON_ERROR
             );
-            if (empty($response['value']['previewProviders']) || empty($response['value']['options'])) {
+            if (empty($response['value']['providers']) || empty($response['value']['options'])) {
                 throw new RuntimeException('Previewer configuration missing.');
             }
         } catch (GuzzleException | JsonException | RuntimeException $exception) {
@@ -335,9 +335,17 @@ class Previewer extends ServiceModule
         }
 
         try {
+            $runnerProviders = $response['value']['providers'];
+            $constructPreviewProviders = $response['value']['constructPreviewProviders'] ?? [];
+            $providers = [];
+            foreach (['runner', 'itemRunner', 'plugins'] as $key) {
+                $providers[$key] = $constructPreviewProviders[$key] ?? $runnerProviders[$key];
+            }
+            if (isset($constructPreviewProviders['proxy'])) {
+                $providers['proxy'] = $constructPreviewProviders['proxy'];
+            }
             $response = [
-                // we'll read from previewProviders, but serve as providers
-                'providers' => $response['value']['previewProviders'],
+                'providers' => $providers,
                 'options' => $response['value']['options']
             ];
         } catch (Exception $e) {

--- a/controller/Previewer.php
+++ b/controller/Previewer.php
@@ -336,13 +336,13 @@ class Previewer extends ServiceModule
 
         try {
             $runnerProviders = $response['value']['providers'];
-            $constructPreviewProviders = $response['value']['constructPreviewProviders'] ?? [];
+            $previewProviders = $response['value']['previewProviders'] ?? [];
             $providers = [];
             foreach (['runner', 'itemRunner', 'plugins'] as $key) {
-                $providers[$key] = $constructPreviewProviders[$key] ?? $runnerProviders[$key];
+                $providers[$key] = $previewProviders[$key] ?? $runnerProviders[$key];
             }
-            if (isset($constructPreviewProviders['proxy'])) {
-                $providers['proxy'] = $constructPreviewProviders['proxy'];
+            if (isset($previewProviders['proxy'])) {
+                $providers['proxy'] = $previewProviders['proxy'];
             }
             $response = [
                 'providers' => $providers,

--- a/controller/Previewer.php
+++ b/controller/Previewer.php
@@ -322,7 +322,7 @@ class Previewer extends ServiceModule
                 true,
                 flags: JSON_THROW_ON_ERROR
             );
-            if (empty($response['value']['providers']) || empty($response['value']['options'])) {
+            if (empty($response['value']['previewProviders']) || empty($response['value']['options'])) {
                 throw new RuntimeException('Previewer configuration missing.');
             }
         } catch (GuzzleException | JsonException | RuntimeException $exception) {
@@ -335,17 +335,9 @@ class Previewer extends ServiceModule
         }
 
         try {
-            $runnerProviders = $response['value']['providers'];
-            $previewProviders = $response['value']['previewProviders'] ?? [];
-            $providers = [];
-            foreach (['runner', 'itemRunner', 'plugins'] as $key) {
-                $providers[$key] = $previewProviders[$key] ?? $runnerProviders[$key];
-            }
-            if (isset($previewProviders['proxy'])) {
-                $providers['proxy'] = $previewProviders['proxy'];
-            }
             $response = [
-                'providers' => $providers,
+                // we'll read from previewProviders, but serve as providers
+                'providers' => $response['value']['previewProviders'],
                 'options' => $response['value']['options']
             ];
         } catch (Exception $e) {

--- a/models/test/mapper/TestPreviewMapper.php
+++ b/models/test/mapper/TestPreviewMapper.php
@@ -92,9 +92,13 @@ class TestPreviewMapper extends ConfigurableService implements TestPreviewMapper
                 $itemUri = $itemRef->getHref();
 
                 $allowSkipping = true;
+                $validateResponses = false;
+                $remainingAttempts = -1;
                 $sessionControl = $itemRef->getItemSessionControl();
                 if ($sessionControl !== null) {
                     $allowSkipping = $sessionControl->doesAllowSkipping();
+                    $validateResponses = $sessionControl->mustValidateResponses();
+                    $remainingAttempts = $sessionControl->getMaxAttempts() - 1;
                 }
 
                 $itemInfos = [
@@ -103,12 +107,13 @@ class TestPreviewMapper extends ConfigurableService implements TestPreviewMapper
                     'label' => $this->getItemLabel($itemUri),
                     'position' => $offset,
                     'occurrence' => $occurrence,
-                    'remainingAttempts' => -1,
+                    'remainingAttempts' => $remainingAttempts,
                     'answered' => 0,
                     'flagged' => false,
                     'viewed' => false,
                     'categories' => $itemRef->getCategories()->getArrayCopy(),
                     'allowSkipping' => $allowSkipping,
+                    'validateResponses' => $validateResponses,
                     'hasFeedbacks' => $this->checkHasFeedbacks($itemRef)
                 ];
 

--- a/test/unit/models/test/mapper/TestPreviewMapperTest.php
+++ b/test/unit/models/test/mapper/TestPreviewMapperTest.php
@@ -157,9 +157,14 @@ class TestPreviewMapperTest extends TestCase
     }
 
     /**
-     * @dataProvider provideAllowSkippingVariations
+     * @dataProvider provideSessionControlVariations
      */
-    public function testAllowSkipping(bool $doesAllowSkipping, bool $hasSessionControl = true): void
+    public function testSessionControl(
+        bool $doesAllowSkipping,
+        bool $mustValidateResponses,
+        int $expectedRemainingAttempts,
+        bool $hasSessionControl = true
+    ): void
     {
         $itemId = 'itemId';
         $sectionTitle = 'sectionTitle';
@@ -176,6 +181,9 @@ class TestPreviewMapperTest extends TestCase
         if ($hasSessionControl) {
             $sessionControl = $this->createMock(ItemSessionControl::class);
             $sessionControl->expects($this->once())->method('doesAllowSkipping')->willReturn($doesAllowSkipping);
+            $sessionControl->expects($this->once())->method('mustValidateResponses')->willReturn($mustValidateResponses);
+            $sessionControl->expects($this->once())->method('getMaxAttempts')
+                ->willReturn($expectedRemainingAttempts + 1);
         }
 
         $itemRef = $this->expectsExtendedItemRef('itemUri', $itemId, $categories, $sessionControl);
@@ -184,23 +192,39 @@ class TestPreviewMapperTest extends TestCase
         $this->expectsItemResource('itemUri', 'testLabel');
 
         static::assertEquals(
-            new TestPreviewMap($this->getFullMapData($itemId, $sectionTitle, $categories, true, $doesAllowSkipping)),
+            new TestPreviewMap(
+                $this->getFullMapData(
+                    $itemId,
+                    $sectionTitle,
+                    $categories,
+                    true,
+                    $doesAllowSkipping,
+                    $mustValidateResponses,
+                    $expectedRemainingAttempts
+                )
+            ),
             $this->subject->map($this->expectsTest(), $this->expectsRoute([$routeItem]), $config)
         );
     }
 
-    public function provideAllowSkippingVariations(): array
+    public function provideSessionControlVariations(): array
     {
         return [
-            'without-session-control-set-default-allow-skipping' => [
+            'without-session-control-set-default-values' => [
                 'doesAllowSkipping' => true,
+                'mustValidateResponses' => false,
+                'expectedRemainingAttempts' => -1,
                 'hasSessionControl' => false,
             ],
-            'allow-skipping-disabled' => [
+            'session-control-disables-skipping-and-enables-validation' => [
                 'doesAllowSkipping' => false,
+                'mustValidateResponses' => true,
+                'expectedRemainingAttempts' => 2,
             ],
-            'allow-skipping-enabled' => [
+            'session-control-enables-skipping-and-disables-validation' => [
                 'doesAllowSkipping' => true,
+                'mustValidateResponses' => false,
+                'expectedRemainingAttempts' => 0,
             ],
         ];
     }
@@ -250,7 +274,7 @@ class TestPreviewMapperTest extends TestCase
 
         static::assertEquals(
             new TestPreviewMap(
-                $this->getFullMapData($itemId, $sectionTitle, $categories, true, true, $expectedHasFeedbacks)
+                $this->getFullMapData($itemId, $sectionTitle, $categories, true, true, false, -1, $expectedHasFeedbacks)
             ),
             $this->subject->map($this->expectsTest(), $this->expectsRoute([$routeItem]), $config)
         );
@@ -276,6 +300,8 @@ class TestPreviewMapperTest extends TestCase
         array $categories,
         bool $isInformational = false,
         bool $allowSkipping = true,
+        bool $validateResponses = false,
+        int $remainingAttempts = -1,
         bool $hasFeedbacks = false
     ): array {
         $data = [
@@ -299,12 +325,13 @@ class TestPreviewMapperTest extends TestCase
                                     'label' => 'testLabel',
                                     'position' => 0,
                                     'occurrence' => null,
-                                    'remainingAttempts' => -1,
+                                    'remainingAttempts' => $remainingAttempts,
                                     'answered' => 0,
                                     'flagged' => false,
                                     'viewed' => false,
                                     'categories' => $categories,
                                     'allowSkipping' => $allowSkipping,
+                                    'validateResponses' => $validateResponses,
                                     'hasFeedbacks' => $hasFeedbacks,
                                 ],
                             ],


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TR-6793

For https://github.com/oat-sa/extension-tao-testqti-previewer/pull/243

### Changes
- return `remainingAttempts` & `validateResponses`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview configuration validation and provider selection with better fallbacks and conditional inclusion of proxy settings.
  * Updated preview mapping to honor per-item session controls, producing correct remaining-attempt counts and per-item response-validation flags.

* **Tests**
  * Expanded unit tests to cover session-control variations and validate mapping of new per-item fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->